### PR TITLE
Update dependencies and drop Node.js < 16 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ["14.14.0", 16, 18, 20]
+        node: [16, 18, 20]
         os: [ubuntu-latest, windows-latest]
 
     steps:

--- a/index.js
+++ b/index.js
@@ -4,13 +4,12 @@ import process from 'node:process';
 import contentDisposition from 'content-disposition';
 import archiveType from '@xhmikosr/archive-type';
 import decompress from '@xhmikosr/decompress';
+import defaults from 'defaults';
 import extName from 'ext-name';
 import {fileTypeFromBuffer} from 'file-type';
 import filenamify from 'filenamify';
 import getStream from 'get-stream';
 import got from 'got';
-// TODO replace with `defaults` package when we drop Node.js < 16 support
-import mergeOptions from 'merge-options';
 import {pEvent} from 'p-event';
 
 const getExtFromMime = response => {
@@ -66,7 +65,7 @@ const download = (uri, output, options) => {
 		decompress: {},
 	};
 
-	options = mergeOptions(defaultOptions, options);
+	options = defaults(options, defaultOptions);
 
 	const stream = got.stream(uri, options.got);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,12 +12,12 @@
 				"@xhmikosr/archive-type": "^6.0.1",
 				"@xhmikosr/decompress": "^9.0.1",
 				"content-disposition": "^0.5.4",
+				"defaults": "^2.0.1",
 				"ext-name": "^5.0.0",
 				"file-type": "^18.5.0",
 				"filenamify": "^5.1.1",
 				"get-stream": "^6.0.1",
 				"got": "^12.6.1",
-				"merge-options": "^3.0.4",
 				"p-event": "^5.0.1"
 			},
 			"devDependencies": {
@@ -1880,6 +1880,17 @@
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
 			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
 			"dev": true
+		},
+		"node_modules/defaults": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/defaults/-/defaults-2.0.1.tgz",
+			"integrity": "sha512-1bGZaOcfpx0Iyxc0SqSIJ8O2WZF8xm56p4Yd4be+VxYQlFM5/4Mx3IMZqi96Npl8EsBG2pePlyGVLdqsmtIkag==",
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
 		"node_modules/defer-to-connect": {
 			"version": "2.0.1",
@@ -4369,14 +4380,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/is-plain-obj": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-			"integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/is-plain-object": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
@@ -5240,17 +5243,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/merge-options": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
-			"integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
-			"dependencies": {
-				"is-plain-obj": "^2.1.0"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/merge-stream": {
@@ -10099,6 +10091,11 @@
 			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
 			"dev": true
 		},
+		"defaults": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/defaults/-/defaults-2.0.1.tgz",
+			"integrity": "sha512-1bGZaOcfpx0Iyxc0SqSIJ8O2WZF8xm56p4Yd4be+VxYQlFM5/4Mx3IMZqi96Npl8EsBG2pePlyGVLdqsmtIkag=="
+		},
 		"defer-to-connect": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
@@ -11882,11 +11879,6 @@
 			"integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
 			"dev": true
 		},
-		"is-plain-obj": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-			"integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
-		},
 		"is-plain-object": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
@@ -12494,14 +12486,6 @@
 					"integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
 					"dev": true
 				}
-			}
-		},
-		"merge-options": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
-			"integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
-			"requires": {
-				"is-plain-obj": "^2.1.0"
 			}
 		},
 		"merge-stream": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,21 +12,21 @@
 				"@xhmikosr/archive-type": "^6.0.1",
 				"@xhmikosr/decompress": "^9.0.1",
 				"content-disposition": "^0.5.4",
-				"defaults": "^2.0.1",
+				"defaults": "^2.0.2",
 				"ext-name": "^5.0.0",
-				"file-type": "^18.5.0",
-				"filenamify": "^5.1.1",
+				"file-type": "^18.7.0",
+				"filenamify": "^6.0.0",
 				"get-stream": "^6.0.1",
-				"got": "^12.6.1",
-				"p-event": "^5.0.1"
+				"got": "^13.0.0",
+				"p-event": "^6.0.0"
 			},
 			"devDependencies": {
-				"ava": "^4.3.3",
+				"ava": "^5.3.1",
 				"c8": "^8.0.1",
 				"is-zip": "^1.0.0",
-				"nock": "^13.3.2",
+				"nock": "^13.4.0",
 				"path-exists": "^5.0.0",
-				"xo": "^0.54.2"
+				"xo": "^0.56.0"
 			},
 			"engines": {
 				"node": ">=16"
@@ -42,34 +42,91 @@
 			}
 		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.5.tgz",
-			"integrity": "sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==",
+			"version": "7.23.5",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
+			"integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/highlight": "^7.22.5"
+				"@babel/highlight": "^7.23.4",
+				"chalk": "^2.4.2"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
+		"node_modules/@babel/code-frame/node_modules/ansi-styles": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"dev": true,
+			"dependencies": {
+				"color-convert": "^1.9.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@babel/code-frame/node_modules/chalk": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@babel/code-frame/node_modules/escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.8.0"
+			}
+		},
+		"node_modules/@babel/code-frame/node_modules/has-flag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@babel/code-frame/node_modules/supports-color": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"dev": true,
+			"dependencies": {
+				"has-flag": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz",
-			"integrity": "sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==",
+			"version": "7.22.20",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+			"integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/highlight": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.5.tgz",
-			"integrity": "sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==",
+			"version": "7.23.4",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
+			"integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.22.5",
-				"chalk": "^2.0.0",
+				"@babel/helper-validator-identifier": "^7.22.20",
+				"chalk": "^2.4.2",
 				"js-tokens": "^4.0.0"
 			},
 			"engines": {
@@ -154,23 +211,23 @@
 			}
 		},
 		"node_modules/@eslint-community/regexpp": {
-			"version": "4.6.2",
-			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.6.2.tgz",
-			"integrity": "sha512-pPTNuaAG3QMH+buKyBIGJs3g/S5y0caxw0ygM3YyE6yJFySwiGGSzA+mM3KJ8QQvzeLh3blwgSonkFjgQdxzMw==",
+			"version": "4.10.0",
+			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.0.tgz",
+			"integrity": "sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==",
 			"dev": true,
 			"engines": {
 				"node": "^12.0.0 || ^14.0.0 || >=16.0.0"
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.4.1.tgz",
-			"integrity": "sha512-XXrH9Uarn0stsyldqDYq8r++mROmWRI1xKMXa640Bb//SY1+ECYX6VzT6Lcx5frD0V30XieqJ0oX9I2Xj5aoMA==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+			"integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
 			"dev": true,
 			"dependencies": {
 				"ajv": "^6.12.4",
 				"debug": "^4.3.2",
-				"espree": "^9.4.0",
+				"espree": "^9.6.0",
 				"globals": "^13.19.0",
 				"ignore": "^5.2.0",
 				"import-fresh": "^3.2.1",
@@ -204,21 +261,21 @@
 			}
 		},
 		"node_modules/@eslint/js": {
-			"version": "8.46.0",
-			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.46.0.tgz",
-			"integrity": "sha512-a8TLtmPi8xzPkCbp/OGFUo5yhRkHM2Ko9kOWP4znJr0WAhWyThaw3PnwX4vOTWOAMsV2uRt32PPDcEz63esSaA==",
+			"version": "8.55.0",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.55.0.tgz",
+			"integrity": "sha512-qQfo2mxH5yVom1kacMtZZJFVdW+E70mqHMJvVg6WTLo+VBuQJ4TojZlfWBjK0ve5BdEeNAVxOsl/nvNMpJOaJA==",
 			"dev": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
 		},
 		"node_modules/@humanwhocodes/config-array": {
-			"version": "0.11.10",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
-			"integrity": "sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==",
+			"version": "0.11.13",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.13.tgz",
+			"integrity": "sha512-JSBDMiDKSzQVngfRjOdFXgFfklaXI4K9nLF49Auh21lmBWRLIK3+xTErTWD4KU54pb6coM6ESE7Awz/FNU3zgQ==",
 			"dev": true,
 			"dependencies": {
-				"@humanwhocodes/object-schema": "^1.2.1",
+				"@humanwhocodes/object-schema": "^2.0.1",
 				"debug": "^4.1.1",
 				"minimatch": "^3.0.5"
 			},
@@ -240,9 +297,9 @@
 			}
 		},
 		"node_modules/@humanwhocodes/object-schema": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
-			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.1.tgz",
+			"integrity": "sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==",
 			"dev": true
 		},
 		"node_modules/@istanbuljs/schema": {
@@ -270,9 +327,9 @@
 			}
 		},
 		"node_modules/@jridgewell/resolve-uri": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
-			"integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
+			"integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.0.0"
@@ -300,19 +357,19 @@
 			}
 		},
 		"node_modules/@jridgewell/sourcemap-codec": {
-			"version": "1.4.14",
-			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-			"integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+			"version": "1.4.15",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+			"integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
 			"dev": true
 		},
 		"node_modules/@jridgewell/trace-mapping": {
-			"version": "0.3.18",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.18.tgz",
-			"integrity": "sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==",
+			"version": "0.3.20",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz",
+			"integrity": "sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==",
 			"dev": true,
 			"dependencies": {
-				"@jridgewell/resolve-uri": "3.1.0",
-				"@jridgewell/sourcemap-codec": "1.4.14"
+				"@jridgewell/resolve-uri": "^3.1.0",
+				"@jridgewell/sourcemap-codec": "^1.4.14"
 			}
 		},
 		"node_modules/@nodelib/fs.scandir": {
@@ -350,6 +407,44 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/@pkgr/utils": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/@pkgr/utils/-/utils-2.4.2.tgz",
+			"integrity": "sha512-POgTXhjrTfbTV63DiFXav4lBHiICLKKwDeaKn9Nphwj7WH6m0hMMCaJkMyRWjgtPFyRKRVoMXXjczsTQRDEhYw==",
+			"dev": true,
+			"dependencies": {
+				"cross-spawn": "^7.0.3",
+				"fast-glob": "^3.3.0",
+				"is-glob": "^4.0.3",
+				"open": "^9.1.0",
+				"picocolors": "^1.0.0",
+				"tslib": "^2.6.0"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/unts"
+			}
+		},
+		"node_modules/@pkgr/utils/node_modules/open": {
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/open/-/open-9.1.0.tgz",
+			"integrity": "sha512-OS+QTnw1/4vrf+9hh1jc1jnYjzSG4ttTBB8UxOwAnInG3Uo4ssetzC1ihqaIHjLJnA5GGlRl6QlZXOTQhRBUvg==",
+			"dev": true,
+			"dependencies": {
+				"default-browser": "^4.0.0",
+				"define-lazy-prop": "^3.0.0",
+				"is-inside-container": "^1.0.0",
+				"is-wsl": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/@sindresorhus/is": {
 			"version": "5.6.0",
 			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-5.6.0.tgz",
@@ -378,9 +473,9 @@
 			"integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
 		},
 		"node_modules/@types/eslint": {
-			"version": "8.44.1",
-			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.44.1.tgz",
-			"integrity": "sha512-XpNDc4Z5Tb4x+SW1MriMVeIsMoONHCkWFMkR/aPJbzEsxqHy+4Glu/BqTdPrApfDeMaXbtNh6bseNgl5KaWrSg==",
+			"version": "8.44.8",
+			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.44.8.tgz",
+			"integrity": "sha512-4K8GavROwhrYl2QXDXm0Rv9epkA8GBFu0EI+XrrnnuCl7u8CWBRusX7fXJfanhZTDWSAL24gDI/UqXyUM0Injw==",
 			"dev": true,
 			"dependencies": {
 				"@types/estree": "*",
@@ -388,9 +483,9 @@
 			}
 		},
 		"node_modules/@types/eslint-scope": {
-			"version": "3.7.4",
-			"resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.4.tgz",
-			"integrity": "sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==",
+			"version": "3.7.7",
+			"resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
+			"integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
@@ -399,26 +494,26 @@
 			}
 		},
 		"node_modules/@types/estree": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.1.tgz",
-			"integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+			"integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
 			"dev": true
 		},
 		"node_modules/@types/http-cache-semantics": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
-			"integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ=="
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
+			"integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA=="
 		},
 		"node_modules/@types/istanbul-lib-coverage": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
-			"integrity": "sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g==",
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+			"integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
 			"dev": true
 		},
 		"node_modules/@types/json-schema": {
-			"version": "7.0.12",
-			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
-			"integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
+			"version": "7.0.15",
+			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+			"integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
 			"dev": true
 		},
 		"node_modules/@types/json5": {
@@ -427,23 +522,250 @@
 			"integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
 			"dev": true
 		},
-		"node_modules/@types/minimist": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
-			"integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
-			"dev": true
-		},
 		"node_modules/@types/node": {
-			"version": "20.4.5",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.5.tgz",
-			"integrity": "sha512-rt40Nk13II9JwQBdeYqmbn2Q6IVTA5uPhvSO+JVqdXw/6/4glI6oR9ezty/A9Hg5u7JH4OmYmuQ+XvjKm0Datg==",
+			"version": "20.10.4",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.4.tgz",
+			"integrity": "sha512-D08YG6rr8X90YB56tSIuBaddy/UXAA9RKJoFvrsnogAum/0pmjkgi4+2nx96A330FmioegBWmEYQ+syqCFaveg==",
 			"dev": true,
-			"peer": true
+			"peer": true,
+			"dependencies": {
+				"undici-types": "~5.26.4"
+			}
 		},
 		"node_modules/@types/normalize-package-data": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
-			"integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
+			"version": "2.4.4",
+			"resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
+			"integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
+			"dev": true
+		},
+		"node_modules/@types/semver": {
+			"version": "7.5.6",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.6.tgz",
+			"integrity": "sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==",
+			"dev": true
+		},
+		"node_modules/@typescript-eslint/eslint-plugin": {
+			"version": "6.13.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.13.2.tgz",
+			"integrity": "sha512-3+9OGAWHhk4O1LlcwLBONbdXsAhLjyCFogJY/cWy2lxdVJ2JrcTF2pTGMaLl2AE7U1l31n8Py4a8bx5DLf/0dQ==",
+			"dev": true,
+			"dependencies": {
+				"@eslint-community/regexpp": "^4.5.1",
+				"@typescript-eslint/scope-manager": "6.13.2",
+				"@typescript-eslint/type-utils": "6.13.2",
+				"@typescript-eslint/utils": "6.13.2",
+				"@typescript-eslint/visitor-keys": "6.13.2",
+				"debug": "^4.3.4",
+				"graphemer": "^1.4.0",
+				"ignore": "^5.2.4",
+				"natural-compare": "^1.4.0",
+				"semver": "^7.5.4",
+				"ts-api-utils": "^1.0.1"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
+				"eslint": "^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@typescript-eslint/parser": {
+			"version": "6.13.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.13.2.tgz",
+			"integrity": "sha512-MUkcC+7Wt/QOGeVlM8aGGJZy1XV5YKjTpq9jK6r6/iLsGXhBVaGP5N0UYvFsu9BFlSpwY9kMretzdBH01rkRXg==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/scope-manager": "6.13.2",
+				"@typescript-eslint/types": "6.13.2",
+				"@typescript-eslint/typescript-estree": "6.13.2",
+				"@typescript-eslint/visitor-keys": "6.13.2",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@typescript-eslint/scope-manager": {
+			"version": "6.13.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.13.2.tgz",
+			"integrity": "sha512-CXQA0xo7z6x13FeDYCgBkjWzNqzBn8RXaE3QVQVIUm74fWJLkJkaHmHdKStrxQllGh6Q4eUGyNpMe0b1hMkXFA==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/types": "6.13.2",
+				"@typescript-eslint/visitor-keys": "6.13.2"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/type-utils": {
+			"version": "6.13.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.13.2.tgz",
+			"integrity": "sha512-Qr6ssS1GFongzH2qfnWKkAQmMUyZSyOr0W54nZNU1MDfo+U4Mv3XveeLZzadc/yq8iYhQZHYT+eoXJqnACM1tw==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/typescript-estree": "6.13.2",
+				"@typescript-eslint/utils": "6.13.2",
+				"debug": "^4.3.4",
+				"ts-api-utils": "^1.0.1"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@typescript-eslint/types": {
+			"version": "6.13.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.13.2.tgz",
+			"integrity": "sha512-7sxbQ+EMRubQc3wTfTsycgYpSujyVbI1xw+3UMRUcrhSy+pN09y/lWzeKDbvhoqcRbHdc+APLs/PWYi/cisLPg==",
+			"dev": true,
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/typescript-estree": {
+			"version": "6.13.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.13.2.tgz",
+			"integrity": "sha512-SuD8YLQv6WHnOEtKv8D6HZUzOub855cfPnPMKvdM/Bh1plv1f7Q/0iFUDLKKlxHcEstQnaUU4QZskgQq74t+3w==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/types": "6.13.2",
+				"@typescript-eslint/visitor-keys": "6.13.2",
+				"debug": "^4.3.4",
+				"globby": "^11.1.0",
+				"is-glob": "^4.0.3",
+				"semver": "^7.5.4",
+				"ts-api-utils": "^1.0.1"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@typescript-eslint/typescript-estree/node_modules/globby": {
+			"version": "11.1.0",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+			"integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+			"dev": true,
+			"dependencies": {
+				"array-union": "^2.1.0",
+				"dir-glob": "^3.0.1",
+				"fast-glob": "^3.2.9",
+				"ignore": "^5.2.0",
+				"merge2": "^1.4.1",
+				"slash": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@typescript-eslint/typescript-estree/node_modules/slash": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@typescript-eslint/utils": {
+			"version": "6.13.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.13.2.tgz",
+			"integrity": "sha512-b9Ptq4eAZUym4idijCRzl61oPCwwREcfDI8xGk751Vhzig5fFZR9CyzDz4Sp/nxSLBYxUPyh4QdIDqWykFhNmQ==",
+			"dev": true,
+			"dependencies": {
+				"@eslint-community/eslint-utils": "^4.4.0",
+				"@types/json-schema": "^7.0.12",
+				"@types/semver": "^7.5.0",
+				"@typescript-eslint/scope-manager": "6.13.2",
+				"@typescript-eslint/types": "6.13.2",
+				"@typescript-eslint/typescript-estree": "6.13.2",
+				"semver": "^7.5.4"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^7.0.0 || ^8.0.0"
+			}
+		},
+		"node_modules/@typescript-eslint/visitor-keys": {
+			"version": "6.13.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.13.2.tgz",
+			"integrity": "sha512-OGznFs0eAQXJsp+xSd6k/O1UbFi/K/L7WjqeRoFE7vadjAF9y0uppXhYNQNEqygjou782maGClOoZwPqF0Drlw==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/types": "6.13.2",
+				"eslint-visitor-keys": "^3.4.1"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@ungap/structured-clone": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
+			"integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
 			"dev": true
 		},
 		"node_modules/@webassemblyjs/ast": {
@@ -704,9 +1026,9 @@
 			"peer": true
 		},
 		"node_modules/acorn": {
-			"version": "8.10.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
-			"integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+			"version": "8.11.2",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
+			"integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
 			"dev": true,
 			"bin": {
 				"acorn": "bin/acorn"
@@ -735,9 +1057,9 @@
 			}
 		},
 		"node_modules/acorn-walk": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-			"integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+			"version": "8.3.1",
+			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.1.tgz",
+			"integrity": "sha512-TgUZgYvqZprrl7YldZNoa9OciCAyZR+Ejm9eXzKCmjsF5IKp/wgQ7Z/ZpjpGTIUPwrHQIcYeI8qDh4PsEwxMbw==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.4.0"
@@ -871,12 +1193,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/array-find": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/array-find/-/array-find-1.0.0.tgz",
-			"integrity": "sha512-kO/vVCacW9mnpn3WPWbTVlEnOabK2L7LWi2HViURtCM46y1zb6I8UMjx4LgbiqadTgHnLInUronwn3ampNTJtQ==",
-			"dev": true
-		},
 		"node_modules/array-find-index": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
@@ -887,15 +1203,15 @@
 			}
 		},
 		"node_modules/array-includes": {
-			"version": "3.1.6",
-			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.6.tgz",
-			"integrity": "sha512-sgTbLvL6cNnw24FnbaDyjmvddQ2ML8arZsgaJhoABMoplz/4QRhtrYS+alr1BUM1Bwp6dhx8vVCBSLG+StwOFw==",
+			"version": "3.1.7",
+			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.7.tgz",
+			"integrity": "sha512-dlcsNBIiWhPkHdOEEKnehA+RNUWDc4UqFtnIXU4uuYDPtA4LDkr7qip2p0VvFAEXNDr0yWZ9PJyIRiGjRLQzwQ==",
 			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.4",
-				"es-abstract": "^1.20.4",
-				"get-intrinsic": "^1.1.3",
+				"define-properties": "^1.2.0",
+				"es-abstract": "^1.22.1",
+				"get-intrinsic": "^1.2.1",
 				"is-string": "^1.0.7"
 			},
 			"engines": {
@@ -914,34 +1230,30 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/array.prototype.findlastindex": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.2.tgz",
-			"integrity": "sha512-tb5thFFlUcp7NdNF6/MpDk/1r/4awWG1FIz3YqDf+/zJSTezBb+/5WViH41obXULHVpDzoiCLpJ/ZO9YbJMsdw==",
+		"node_modules/array.prototype.find": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.2.2.tgz",
+			"integrity": "sha512-DRumkfW97iZGOfn+lIXbkVrXL04sfYKX+EfOodo8XboR5sxPDVvOjZTF/rysusa9lmhmSOeD6Vp6RKQP+eP4Tg==",
 			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.4",
-				"es-abstract": "^1.20.4",
-				"es-shim-unscopables": "^1.0.0",
-				"get-intrinsic": "^1.1.3"
-			},
-			"engines": {
-				"node": ">= 0.4"
+				"define-properties": "^1.2.0",
+				"es-abstract": "^1.22.1",
+				"es-shim-unscopables": "^1.0.0"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/array.prototype.flat": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.1.tgz",
-			"integrity": "sha512-roTU0KWIOmJ4DRLmwKd19Otg0/mT3qPNt0Qb3GWW8iObuZXxrjB/pzn0R3hqpRSWg4HCwqx+0vwOnWnvlOyeIA==",
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.2.tgz",
+			"integrity": "sha512-djYB+Zx2vLewY8RWlNCUdHjDXs2XOgm602S9E7P/UpHgfeHL00cRiIF+IN/G/aUJ7kGPb6yO/ErDI5V2s8iycA==",
 			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.4",
-				"es-abstract": "^1.20.4",
+				"define-properties": "^1.2.0",
+				"es-abstract": "^1.22.1",
 				"es-shim-unscopables": "^1.0.0"
 			},
 			"engines": {
@@ -952,14 +1264,14 @@
 			}
 		},
 		"node_modules/array.prototype.flatmap": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.1.tgz",
-			"integrity": "sha512-8UGn9O1FDVvMNB0UlLv4voxRMze7+FpHyF5mSMRjWHUMlpoDViniy05870VlxhfgTnLbpuwTzvD76MTtWxB/mQ==",
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.2.tgz",
+			"integrity": "sha512-Ewyx0c9PmpcsByhSW4r+9zDU7sGjFc86qf/kKtuSCRdhfbk0SNLLkaT5qvcHnRGgc5NP/ly/y+qkXkqONX54CQ==",
 			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.4",
-				"es-abstract": "^1.20.4",
+				"define-properties": "^1.2.0",
+				"es-abstract": "^1.22.1",
 				"es-shim-unscopables": "^1.0.0"
 			},
 			"engines": {
@@ -970,14 +1282,15 @@
 			}
 		},
 		"node_modules/arraybuffer.prototype.slice": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.1.tgz",
-			"integrity": "sha512-09x0ZWFEjj4WD8PDbykUwo3t9arLn8NIzmmYEJFpYekOAQjpkGSyrQhNoRTcwwcFRu+ycWF78QZ63oWTqSjBcw==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.2.tgz",
+			"integrity": "sha512-yMBKppFur/fbHu9/6USUe03bZ4knMYiwFBcyiaXB8Go0qNehwX6inYPzK9U0NeQvGxKthcmHcaR8P5MStSRBAw==",
 			"dev": true,
 			"dependencies": {
 				"array-buffer-byte-length": "^1.0.0",
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.2.0",
+				"es-abstract": "^1.22.1",
 				"get-intrinsic": "^1.2.1",
 				"is-array-buffer": "^3.0.2",
 				"is-shared-array-buffer": "^1.0.2"
@@ -1011,22 +1324,22 @@
 			}
 		},
 		"node_modules/ava": {
-			"version": "4.3.3",
-			"resolved": "https://registry.npmjs.org/ava/-/ava-4.3.3.tgz",
-			"integrity": "sha512-9Egq/d9R74ExrWohHeqUlexjDbgZJX5jA1Wq4KCTqc3wIfpGEK79zVy4rBtofJ9YKIxs4PzhJ8BgbW5PlAYe6w==",
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/ava/-/ava-5.3.1.tgz",
+			"integrity": "sha512-Scv9a4gMOXB6+ni4toLuhAm9KYWEjsgBglJl+kMGI5+IVDt120CCDZyB5HNU9DjmLI2t4I0GbnxGLmmRfGTJGg==",
 			"dev": true,
 			"dependencies": {
-				"acorn": "^8.7.1",
+				"acorn": "^8.8.2",
 				"acorn-walk": "^8.2.0",
-				"ansi-styles": "^6.1.0",
+				"ansi-styles": "^6.2.1",
 				"arrgv": "^1.0.2",
 				"arrify": "^3.0.0",
 				"callsites": "^4.0.0",
 				"cbor": "^8.1.0",
-				"chalk": "^5.0.1",
+				"chalk": "^5.2.0",
 				"chokidar": "^3.5.3",
 				"chunkd": "^2.0.1",
-				"ci-info": "^3.3.1",
+				"ci-info": "^3.8.0",
 				"ci-parallel-vars": "^1.0.1",
 				"clean-yaml-object": "^0.1.0",
 				"cli-truncate": "^3.1.0",
@@ -1035,10 +1348,9 @@
 				"concordance": "^5.0.4",
 				"currently-unhandled": "^0.4.1",
 				"debug": "^4.3.4",
-				"del": "^6.1.1",
-				"emittery": "^0.11.0",
-				"figures": "^4.0.1",
-				"globby": "^13.1.1",
+				"emittery": "^1.0.1",
+				"figures": "^5.0.0",
+				"globby": "^13.1.4",
 				"ignore-by-default": "^2.1.0",
 				"indent-string": "^5.0.0",
 				"is-error": "^2.2.2",
@@ -1048,25 +1360,24 @@
 				"mem": "^9.0.2",
 				"ms": "^2.1.3",
 				"p-event": "^5.0.1",
-				"p-map": "^5.4.0",
+				"p-map": "^5.5.0",
 				"picomatch": "^2.3.1",
 				"pkg-conf": "^4.0.0",
 				"plur": "^5.1.0",
-				"pretty-ms": "^7.0.1",
+				"pretty-ms": "^8.0.0",
 				"resolve-cwd": "^3.0.0",
-				"slash": "^3.0.0",
-				"stack-utils": "^2.0.5",
+				"stack-utils": "^2.0.6",
 				"strip-ansi": "^7.0.1",
 				"supertap": "^3.0.1",
-				"temp-dir": "^2.0.0",
-				"write-file-atomic": "^4.0.1",
-				"yargs": "^17.5.1"
+				"temp-dir": "^3.0.0",
+				"write-file-atomic": "^5.0.1",
+				"yargs": "^17.7.2"
 			},
 			"bin": {
 				"ava": "entrypoints/cli.mjs"
 			},
 			"engines": {
-				"node": ">=12.22 <13 || >=14.17 <15 || >=16.4 <17 || >=18"
+				"node": ">=14.19 <15 || >=16.15 <17 || >=18"
 			},
 			"peerDependencies": {
 				"@ava/typescript": "*"
@@ -1075,6 +1386,33 @@
 				"@ava/typescript": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/ava/node_modules/p-event": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/p-event/-/p-event-5.0.1.tgz",
+			"integrity": "sha512-dd589iCQ7m1L0bmC5NLlVYfy3TbBEsMUfWx9PyAgPeIcFZ/E2yaTZ4Rz4MiBmmJShviiftHVXOqfnfzJ6kyMrQ==",
+			"dev": true,
+			"dependencies": {
+				"p-timeout": "^5.0.2"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/ava/node_modules/p-timeout": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-5.1.0.tgz",
+			"integrity": "sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/available-typed-arrays": {
@@ -1119,6 +1457,15 @@
 				}
 			]
 		},
+		"node_modules/big-integer": {
+			"version": "1.6.52",
+			"resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
+			"integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.6"
+			}
+		},
 		"node_modules/binary-extensions": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -1133,6 +1480,18 @@
 			"resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.19.0.tgz",
 			"integrity": "sha512-DRQrD6gJyy8FbiE4s+bDoXS9hiW3Vbx5uCdwvcCf3zLHL+Iv7LtGHLpr+GZV8rHG8tK766FGYBwRbu8pELTt+w==",
 			"dev": true
+		},
+		"node_modules/bplist-parser": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.2.0.tgz",
+			"integrity": "sha512-z0M+byMThzQmD9NILRniCUXYsYpjwnlO8N5uCFaCqIOpqRsJCrQL9NK3JsD67CN5a08nF5oIL2bD6loTdHOuKw==",
+			"dev": true,
+			"dependencies": {
+				"big-integer": "^1.6.44"
+			},
+			"engines": {
+				"node": ">= 5.10.0"
+			}
 		},
 		"node_modules/brace-expansion": {
 			"version": "1.1.11",
@@ -1157,9 +1516,9 @@
 			}
 		},
 		"node_modules/browserslist": {
-			"version": "4.21.10",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.10.tgz",
-			"integrity": "sha512-bipEBdZfVH5/pwrvqc+Ub0kUPVfGUhlKxbvfD+z1BDnPEO/X98ruXGA1WP5ASpAFKan7Qr6j736IacbZQuAlKQ==",
+			"version": "4.22.2",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.2.tgz",
+			"integrity": "sha512-0UgcrvQmBDvZHFGdYUehrCNIazki7/lUP3kkoi/r3YB2amZbFM9J43ZRkJTXBUZK4gmx56+Sqk9+Vs9mwZx9+A==",
 			"dev": true,
 			"funding": [
 				{
@@ -1177,10 +1536,10 @@
 			],
 			"peer": true,
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001517",
-				"electron-to-chromium": "^1.4.477",
-				"node-releases": "^2.0.13",
-				"update-browserslist-db": "^1.0.11"
+				"caniuse-lite": "^1.0.30001565",
+				"electron-to-chromium": "^1.4.601",
+				"node-releases": "^2.0.14",
+				"update-browserslist-db": "^1.0.13"
 			},
 			"bin": {
 				"browserslist": "cli.js"
@@ -1248,6 +1607,21 @@
 				"semver": "^7.0.0"
 			}
 		},
+		"node_modules/bundle-name": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-3.0.0.tgz",
+			"integrity": "sha512-PKA4BeSvBpQKQ8iPOGCSiell+N8P+Tf1DlwqmYhpe2gAhKPHn8EYOxVT+ShuGmhg8lN8XiSlS80yiExKXrURlw==",
+			"dev": true,
+			"dependencies": {
+				"run-applescript": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/c8": {
 			"version": "8.0.1",
 			"resolved": "https://registry.npmjs.org/c8/-/c8-8.0.1.tgz",
@@ -1283,11 +1657,11 @@
 			}
 		},
 		"node_modules/cacheable-request": {
-			"version": "10.2.13",
-			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-10.2.13.tgz",
-			"integrity": "sha512-3SD4rrMu1msNGEtNSt8Od6enwdo//U9s4ykmXfA2TD58kcLkCobtCDiby7kNyj7a/Q7lz/mAesAFI54rTdnvBA==",
+			"version": "10.2.14",
+			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-10.2.14.tgz",
+			"integrity": "sha512-zkDT5WAF4hSSoUgyfg5tFIxz8XQK+25W/TLVojJTMKBaxevLBBtLxgqguAuVQB8PVW79FVjHcU+GJ9tVbDZ9mQ==",
 			"dependencies": {
-				"@types/http-cache-semantics": "^4.0.1",
+				"@types/http-cache-semantics": "^4.0.2",
 				"get-stream": "^6.0.1",
 				"http-cache-semantics": "^4.1.1",
 				"keyv": "^4.5.3",
@@ -1300,76 +1674,23 @@
 			}
 		},
 		"node_modules/call-bind": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-			"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.5.tgz",
+			"integrity": "sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==",
 			"dev": true,
 			"dependencies": {
-				"function-bind": "^1.1.1",
-				"get-intrinsic": "^1.0.2"
+				"function-bind": "^1.1.2",
+				"get-intrinsic": "^1.2.1",
+				"set-function-length": "^1.1.1"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/callsites": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/callsites/-/callsites-4.0.0.tgz",
-			"integrity": "sha512-y3jRROutgpKdz5vzEhWM34TidDU8vkJppF8dszITeb1PQmSqV3DTxyV8G/lyO/DNvtE1YTedehmw9MPZsCBHxQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=12.20"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/camelcase": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-7.0.1.tgz",
-			"integrity": "sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==",
-			"dev": true,
-			"engines": {
-				"node": ">=14.16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/camelcase-keys": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-8.0.2.tgz",
-			"integrity": "sha512-qMKdlOfsjlezMqxkUGGMaWWs17i2HoL15tM+wtx8ld4nLrUwU58TFdvyGOz/piNP842KeO8yXvggVQSdQ828NA==",
-			"dev": true,
-			"dependencies": {
-				"camelcase": "^7.0.0",
-				"map-obj": "^4.3.0",
-				"quick-lru": "^6.1.1",
-				"type-fest": "^2.13.0"
-			},
-			"engines": {
-				"node": ">=14.16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/camelcase-keys/node_modules/quick-lru": {
-			"version": "6.1.1",
-			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-6.1.1.tgz",
-			"integrity": "sha512-S27GBT+F0NTRiehtbrgaSE1idUAJ5bX8dPAQTdylEyNlrdcH5X4Lz7Edz3DYzecbsCluD5zO8ZNEe04z3D3u6Q==",
-			"dev": true,
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/camelcase-keys/node_modules/type-fest": {
-			"version": "2.19.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-			"integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/callsites/-/callsites-4.1.0.tgz",
+			"integrity": "sha512-aBMbD1Xxay75ViYezwT40aQONfr+pSXTHwNKvIXhXD6+LY3F1dLIcceoC5OZKBVHbXcysz1hL9D2w0JJIMXpUw==",
 			"dev": true,
 			"engines": {
 				"node": ">=12.20"
@@ -1379,9 +1700,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001518",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001518.tgz",
-			"integrity": "sha512-rup09/e3I0BKjncL+FesTayKtPrdwKhUufQFd3riFw1hHg8JmIFoInYfB102cFcY/pPgGmdyl/iy+jgiDi2vdA==",
+			"version": "1.0.30001566",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001566.tgz",
+			"integrity": "sha512-ggIhCsTxmITBAMmK8yZjEhCO5/47jKXPu6Dha/wuCS4JePVL+3uiDEBuhu2aIoT+bqTOR8L76Ip1ARL9xYsEJA==",
 			"dev": true,
 			"funding": [
 				{
@@ -1467,9 +1788,9 @@
 			"dev": true
 		},
 		"node_modules/ci-info": {
-			"version": "3.8.0",
-			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.8.0.tgz",
-			"integrity": "sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==",
+			"version": "3.9.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+			"integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -1693,9 +2014,9 @@
 			}
 		},
 		"node_modules/convert-source-map": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-			"integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
 			"dev": true
 		},
 		"node_modules/convert-to-spaces": {
@@ -1708,14 +2029,14 @@
 			}
 		},
 		"node_modules/cosmiconfig": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.2.0.tgz",
-			"integrity": "sha512-3rTMnFJA1tCOPwRxtgF4wd7Ab2qvDbL8jX+3smjIbS4HlZBagTlpERbdN7iAbWlrfxE3M8c27kTwTawQ7st+OQ==",
+			"version": "8.3.6",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
+			"integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
 			"dev": true,
 			"dependencies": {
-				"import-fresh": "^3.2.1",
+				"import-fresh": "^3.3.0",
 				"js-yaml": "^4.1.0",
-				"parse-json": "^5.0.0",
+				"parse-json": "^5.2.0",
 				"path-type": "^4.0.0"
 			},
 			"engines": {
@@ -1723,6 +2044,14 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/d-fischer"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.9.5"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/cosmiconfig/node_modules/argparse": {
@@ -1804,52 +2133,6 @@
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 			"dev": true
 		},
-		"node_modules/decamelize": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-6.0.0.tgz",
-			"integrity": "sha512-Fv96DCsdOgB6mdGl67MT5JaTNKRzrzill5OH5s8bjYJXVlcXyPYGyPsUkWyGV5p1TXI5esYIYMMeDJL0hEIwaA==",
-			"dev": true,
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/decamelize-keys": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.1.tgz",
-			"integrity": "sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==",
-			"dev": true,
-			"dependencies": {
-				"decamelize": "^1.1.0",
-				"map-obj": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/decamelize-keys/node_modules/decamelize": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-			"integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/decamelize-keys/node_modules/map-obj": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-			"integrity": "sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/decompress-response": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
@@ -1881,10 +2164,130 @@
 			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
 			"dev": true
 		},
+		"node_modules/default-browser": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/default-browser/-/default-browser-4.0.0.tgz",
+			"integrity": "sha512-wX5pXO1+BrhMkSbROFsyxUm0i/cJEScyNhA4PPxc41ICuv05ZZB/MX28s8aZx6xjmatvebIapF6hLEKEcpneUA==",
+			"dev": true,
+			"dependencies": {
+				"bundle-name": "^3.0.0",
+				"default-browser-id": "^3.0.0",
+				"execa": "^7.1.1",
+				"titleize": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/default-browser-id": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-3.0.0.tgz",
+			"integrity": "sha512-OZ1y3y0SqSICtE8DE4S8YOE9UZOJ8wO16fKWVP5J1Qz42kV9jcnMVFrEE/noXb/ss3Q4pZIH79kxofzyNNtUNA==",
+			"dev": true,
+			"dependencies": {
+				"bplist-parser": "^0.2.0",
+				"untildify": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/default-browser/node_modules/execa": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-7.2.0.tgz",
+			"integrity": "sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==",
+			"dev": true,
+			"dependencies": {
+				"cross-spawn": "^7.0.3",
+				"get-stream": "^6.0.1",
+				"human-signals": "^4.3.0",
+				"is-stream": "^3.0.0",
+				"merge-stream": "^2.0.0",
+				"npm-run-path": "^5.1.0",
+				"onetime": "^6.0.0",
+				"signal-exit": "^3.0.7",
+				"strip-final-newline": "^3.0.0"
+			},
+			"engines": {
+				"node": "^14.18.0 || ^16.14.0 || >=18.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/execa?sponsor=1"
+			}
+		},
+		"node_modules/default-browser/node_modules/human-signals": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-4.3.1.tgz",
+			"integrity": "sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=14.18.0"
+			}
+		},
+		"node_modules/default-browser/node_modules/npm-run-path": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
+			"integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
+			"dev": true,
+			"dependencies": {
+				"path-key": "^4.0.0"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/default-browser/node_modules/onetime": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+			"integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+			"dev": true,
+			"dependencies": {
+				"mimic-fn": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/default-browser/node_modules/path-key": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+			"integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/default-browser/node_modules/strip-final-newline": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+			"integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/defaults": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/defaults/-/defaults-2.0.1.tgz",
-			"integrity": "sha512-1bGZaOcfpx0Iyxc0SqSIJ8O2WZF8xm56p4Yd4be+VxYQlFM5/4Mx3IMZqi96Npl8EsBG2pePlyGVLdqsmtIkag==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/defaults/-/defaults-2.0.2.tgz",
+			"integrity": "sha512-cuIw0PImdp76AOfgkjbW4VhQODRmNNcKR73vdCH5cLd/ifj7aamfoXvYgfGkEAjNJZ3ozMIy9Gu2LutUkGEPbA==",
 			"engines": {
 				"node": ">=16"
 			},
@@ -1900,6 +2303,20 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/define-data-property": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.1.tgz",
+			"integrity": "sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==",
+			"dev": true,
+			"dependencies": {
+				"get-intrinsic": "^1.2.1",
+				"gopd": "^1.0.1",
+				"has-property-descriptors": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/define-lazy-prop": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
@@ -1913,11 +2330,12 @@
 			}
 		},
 		"node_modules/define-properties": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.0.tgz",
-			"integrity": "sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+			"integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
 			"dev": true,
 			"dependencies": {
+				"define-data-property": "^1.0.1",
 				"has-property-descriptors": "^1.0.0",
 				"object-keys": "^1.1.1"
 			},
@@ -1926,94 +2344,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/del": {
-			"version": "6.1.1",
-			"resolved": "https://registry.npmjs.org/del/-/del-6.1.1.tgz",
-			"integrity": "sha512-ua8BhapfP0JUJKC/zV9yHHDW/rDoDxP4Zhn3AkA6/xT6gY7jYXJiaeyBZznYVujhZZET+UgcbZiQ7sN3WqcImg==",
-			"dev": true,
-			"dependencies": {
-				"globby": "^11.0.1",
-				"graceful-fs": "^4.2.4",
-				"is-glob": "^4.0.1",
-				"is-path-cwd": "^2.2.0",
-				"is-path-inside": "^3.0.2",
-				"p-map": "^4.0.0",
-				"rimraf": "^3.0.2",
-				"slash": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/del/node_modules/aggregate-error": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
-			"integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-			"dev": true,
-			"dependencies": {
-				"clean-stack": "^2.0.0",
-				"indent-string": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/del/node_modules/clean-stack": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-			"integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/del/node_modules/globby": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-			"integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-			"dev": true,
-			"dependencies": {
-				"array-union": "^2.1.0",
-				"dir-glob": "^3.0.1",
-				"fast-glob": "^3.2.9",
-				"ignore": "^5.2.0",
-				"merge2": "^1.4.1",
-				"slash": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/del/node_modules/indent-string": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-			"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/del/node_modules/p-map": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-			"integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-			"dev": true,
-			"dependencies": {
-				"aggregate-error": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/dir-glob": {
@@ -2047,19 +2377,19 @@
 			"dev": true
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.479",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.479.tgz",
-			"integrity": "sha512-ABv1nHMIR8I5n3O3Een0gr6i0mfM+YcTZqjHy3pAYaOjgFG+BMquuKrSyfYf5CbEkLr9uM05RA3pOk4udNB/aQ==",
+			"version": "1.4.609",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.609.tgz",
+			"integrity": "sha512-ihiCP7PJmjoGNuLpl7TjNA8pCQWu09vGyjlPYw1Rqww4gvNuCcmvl+44G+2QyJ6S2K4o+wbTS++Xz0YN8Q9ERw==",
 			"dev": true,
 			"peer": true
 		},
 		"node_modules/emittery": {
-			"version": "0.11.0",
-			"resolved": "https://registry.npmjs.org/emittery/-/emittery-0.11.0.tgz",
-			"integrity": "sha512-S/7tzL6v5i+4iJd627Nhv9cLFIo5weAIlGccqJFpnBoDB8U1TF2k5tez4J/QNuxyyhWuFqHg1L84Kd3m7iXg6g==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/emittery/-/emittery-1.0.1.tgz",
+			"integrity": "sha512-2ID6FdrMD9KDLldGesP6317G78K7km/kMcwItRtVFva7I/cSEOIaLpewaUb+YLXVwdAp3Ctfxh/V5zIl1sj7dQ==",
 			"dev": true,
 			"engines": {
-				"node": ">=12"
+				"node": ">=14.16"
 			},
 			"funding": {
 				"url": "https://github.com/sindresorhus/emittery?sponsor=1"
@@ -2119,26 +2449,26 @@
 			}
 		},
 		"node_modules/es-abstract": {
-			"version": "1.22.1",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.22.1.tgz",
-			"integrity": "sha512-ioRRcXMO6OFyRpyzV3kE1IIBd4WG5/kltnzdxSCqoP8CMGs/Li+M1uF5o7lOkZVFjDs+NLesthnF66Pg/0q0Lw==",
+			"version": "1.22.3",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.22.3.tgz",
+			"integrity": "sha512-eiiY8HQeYfYH2Con2berK+To6GrK2RxbPawDkGq4UiCQQfZHb6wX9qQqkbpPqaxQFcl8d9QzZqo0tGE0VcrdwA==",
 			"dev": true,
 			"dependencies": {
 				"array-buffer-byte-length": "^1.0.0",
-				"arraybuffer.prototype.slice": "^1.0.1",
+				"arraybuffer.prototype.slice": "^1.0.2",
 				"available-typed-arrays": "^1.0.5",
-				"call-bind": "^1.0.2",
+				"call-bind": "^1.0.5",
 				"es-set-tostringtag": "^2.0.1",
 				"es-to-primitive": "^1.2.1",
-				"function.prototype.name": "^1.1.5",
-				"get-intrinsic": "^1.2.1",
+				"function.prototype.name": "^1.1.6",
+				"get-intrinsic": "^1.2.2",
 				"get-symbol-description": "^1.0.0",
 				"globalthis": "^1.0.3",
 				"gopd": "^1.0.1",
-				"has": "^1.0.3",
 				"has-property-descriptors": "^1.0.0",
 				"has-proto": "^1.0.1",
 				"has-symbols": "^1.0.3",
+				"hasown": "^2.0.0",
 				"internal-slot": "^1.0.5",
 				"is-array-buffer": "^3.0.2",
 				"is-callable": "^1.2.7",
@@ -2146,23 +2476,23 @@
 				"is-regex": "^1.1.4",
 				"is-shared-array-buffer": "^1.0.2",
 				"is-string": "^1.0.7",
-				"is-typed-array": "^1.1.10",
+				"is-typed-array": "^1.1.12",
 				"is-weakref": "^1.0.2",
-				"object-inspect": "^1.12.3",
+				"object-inspect": "^1.13.1",
 				"object-keys": "^1.1.1",
 				"object.assign": "^4.1.4",
-				"regexp.prototype.flags": "^1.5.0",
-				"safe-array-concat": "^1.0.0",
+				"regexp.prototype.flags": "^1.5.1",
+				"safe-array-concat": "^1.0.1",
 				"safe-regex-test": "^1.0.0",
-				"string.prototype.trim": "^1.2.7",
-				"string.prototype.trimend": "^1.0.6",
-				"string.prototype.trimstart": "^1.0.6",
+				"string.prototype.trim": "^1.2.8",
+				"string.prototype.trimend": "^1.0.7",
+				"string.prototype.trimstart": "^1.0.7",
 				"typed-array-buffer": "^1.0.0",
 				"typed-array-byte-length": "^1.0.0",
 				"typed-array-byte-offset": "^1.0.0",
 				"typed-array-length": "^1.0.4",
 				"unbox-primitive": "^1.0.2",
-				"which-typed-array": "^1.1.10"
+				"which-typed-array": "^1.1.13"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -2172,33 +2502,33 @@
 			}
 		},
 		"node_modules/es-module-lexer": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.3.0.tgz",
-			"integrity": "sha512-vZK7T0N2CBmBOixhmjdqx2gWVbFZ4DXZ/NyRMZVlJXPa7CyFS+/a4QQsDGDQy9ZfEzxFuNEsMLeQJnKP2p5/JA==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.4.1.tgz",
+			"integrity": "sha512-cXLGjP0c4T3flZJKQSuziYoq7MlT+rnvfZjfp7h+I7K9BNX54kP9nyWvdbwjQ4u1iWbOL4u96fgeZLToQlZC7w==",
 			"dev": true,
 			"peer": true
 		},
 		"node_modules/es-set-tostringtag": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.1.tgz",
-			"integrity": "sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.2.tgz",
+			"integrity": "sha512-BuDyupZt65P9D2D2vA/zqcI3G5xRsklm5N3xCwuiy+/vKy8i0ifdsQP1sLgO4tZDSCaQUSnmC48khknGMV3D2Q==",
 			"dev": true,
 			"dependencies": {
-				"get-intrinsic": "^1.1.3",
-				"has": "^1.0.3",
-				"has-tostringtag": "^1.0.0"
+				"get-intrinsic": "^1.2.2",
+				"has-tostringtag": "^1.0.0",
+				"hasown": "^2.0.0"
 			},
 			"engines": {
 				"node": ">= 0.4"
 			}
 		},
 		"node_modules/es-shim-unscopables": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.0.tgz",
-			"integrity": "sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.2.tgz",
+			"integrity": "sha512-J3yBRXCzDu4ULnQwxyToo/OjdMx6akgVC7K6few0a7F/0wLtmKKN7I73AH5T2836UuXRqN7Qg+IIUw/+YJksRw==",
 			"dev": true,
 			"dependencies": {
-				"has": "^1.0.3"
+				"hasown": "^2.0.0"
 			}
 		},
 		"node_modules/es-to-primitive": {
@@ -2231,6 +2561,7 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
 			"integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+			"dev": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -2239,18 +2570,19 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "8.46.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.46.0.tgz",
-			"integrity": "sha512-cIO74PvbW0qU8e0mIvk5IV3ToWdCq5FYG6gWPHHkx6gNdjlbAYvtfHmlCMXxjcoVaIdwy/IAt3+mDkZkfvb2Dg==",
+			"version": "8.55.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.55.0.tgz",
+			"integrity": "sha512-iyUUAM0PCKj5QpwGfmCAG9XXbZCWsqP/eWAWrG/W0umvjuLRBECwSFdt+rCntju0xEH7teIABPwXpahftIaTdA==",
 			"dev": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.6.1",
-				"@eslint/eslintrc": "^2.1.1",
-				"@eslint/js": "^8.46.0",
-				"@humanwhocodes/config-array": "^0.11.10",
+				"@eslint/eslintrc": "^2.1.4",
+				"@eslint/js": "8.55.0",
+				"@humanwhocodes/config-array": "^0.11.13",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@nodelib/fs.walk": "^1.2.8",
+				"@ungap/structured-clone": "^1.2.0",
 				"ajv": "^6.12.4",
 				"chalk": "^4.0.0",
 				"cross-spawn": "^7.0.2",
@@ -2258,7 +2590,7 @@
 				"doctrine": "^3.0.0",
 				"escape-string-regexp": "^4.0.0",
 				"eslint-scope": "^7.2.2",
-				"eslint-visitor-keys": "^3.4.2",
+				"eslint-visitor-keys": "^3.4.3",
 				"espree": "^9.6.1",
 				"esquery": "^1.4.2",
 				"esutils": "^2.0.2",
@@ -2292,10 +2624,22 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
+		"node_modules/eslint-compat-utils": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/eslint-compat-utils/-/eslint-compat-utils-0.1.2.tgz",
+			"integrity": "sha512-Jia4JDldWnFNIru1Ehx1H5s9/yxiRHY/TimCuUc0jNexew3cF1gI6CYZil1ociakfWO3rRqFjl1mskBblB3RYg==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"peerDependencies": {
+				"eslint": ">=6.0.0"
+			}
+		},
 		"node_modules/eslint-config-prettier": {
-			"version": "8.9.0",
-			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.9.0.tgz",
-			"integrity": "sha512-+sbni7NfVXnOpnRadUA8S28AUlsZt9GjgFvABIRL9Hkn8KqNzOp+7Lw4QWtrwn20KzU3wqu1QoOj2m+7rKRqkA==",
+			"version": "8.10.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.10.0.tgz",
+			"integrity": "sha512-SM8AMJdeQqRYT9O9zguiruQZaN7+z+E4eAP9oiLNGKMtomwaB1E9dcgUD6ZAn/eQAb52USbvezbiljfZUhbJcg==",
 			"dev": true,
 			"bin": {
 				"eslint-config-prettier": "bin/cli.js"
@@ -2320,6 +2664,24 @@
 			},
 			"peerDependencies": {
 				"eslint": ">=8.27.0"
+			}
+		},
+		"node_modules/eslint-config-xo-typescript": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/eslint-config-xo-typescript/-/eslint-config-xo-typescript-1.0.1.tgz",
+			"integrity": "sha512-vPQssnRSUgBFOEfB/KY12CXwltwFSn4RSCfa+w7gjBC2PFQ7Yfgmyei+1XUZ3K+8LRGef2NMJUcxts7PldhDjg==",
+			"dev": true,
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			},
+			"peerDependencies": {
+				"@typescript-eslint/eslint-plugin": ">=6.0.0",
+				"@typescript-eslint/parser": ">=6.0.0",
+				"eslint": ">=8.0.0",
+				"typescript": ">=4.7"
 			}
 		},
 		"node_modules/eslint-formatter-pretty": {
@@ -2459,14 +2821,14 @@
 			}
 		},
 		"node_modules/eslint-import-resolver-node": {
-			"version": "0.3.7",
-			"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.7.tgz",
-			"integrity": "sha512-gozW2blMLJCeFpBwugLTGyvVjNoeo1knonXAcatC6bjPBZitotxdWf7Gimr25N4c0AAOo4eOUfaG82IJPDpqCA==",
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
+			"integrity": "sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==",
 			"dev": true,
 			"dependencies": {
 				"debug": "^3.2.7",
-				"is-core-module": "^2.11.0",
-				"resolve": "^1.22.1"
+				"is-core-module": "^2.13.0",
+				"resolve": "^1.22.4"
 			}
 		},
 		"node_modules/eslint-import-resolver-node/node_modules/debug": {
@@ -2478,23 +2840,40 @@
 				"ms": "^2.1.1"
 			}
 		},
-		"node_modules/eslint-import-resolver-webpack": {
-			"version": "0.13.2",
-			"resolved": "https://registry.npmjs.org/eslint-import-resolver-webpack/-/eslint-import-resolver-webpack-0.13.2.tgz",
-			"integrity": "sha512-XodIPyg1OgE2h5BDErz3WJoK7lawxKTJNhgPNafRST6csC/MZC+L5P6kKqsZGRInpbgc02s/WZMrb4uGJzcuRg==",
+		"node_modules/eslint-import-resolver-node/node_modules/resolve": {
+			"version": "1.22.8",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+			"integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
 			"dev": true,
 			"dependencies": {
-				"array-find": "^1.0.0",
+				"is-core-module": "^2.13.0",
+				"path-parse": "^1.0.7",
+				"supports-preserve-symlinks-flag": "^1.0.0"
+			},
+			"bin": {
+				"resolve": "bin/resolve"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/eslint-import-resolver-webpack": {
+			"version": "0.13.8",
+			"resolved": "https://registry.npmjs.org/eslint-import-resolver-webpack/-/eslint-import-resolver-webpack-0.13.8.tgz",
+			"integrity": "sha512-Y7WIaXWV+Q21Rz/PJgUxiW/FTBOWmU8NTLdz+nz9mMoiz5vAev/fOaQxwD7qRzTfE3HSm1qsxZ5uRd7eX+VEtA==",
+			"dev": true,
+			"dependencies": {
+				"array.prototype.find": "^2.2.2",
 				"debug": "^3.2.7",
 				"enhanced-resolve": "^0.9.1",
 				"find-root": "^1.1.0",
-				"has": "^1.0.3",
+				"hasown": "^2.0.0",
 				"interpret": "^1.4.0",
-				"is-core-module": "^2.7.0",
+				"is-core-module": "^2.13.1",
 				"is-regex": "^1.1.4",
 				"lodash": "^4.17.21",
-				"resolve": "^1.20.0",
-				"semver": "^5.7.1"
+				"resolve": "^2.0.0-next.5",
+				"semver": "^5.7.2"
 			},
 			"engines": {
 				"node": ">= 6"
@@ -2570,47 +2949,24 @@
 				"eslint": ">=8.26.0"
 			}
 		},
-		"node_modules/eslint-plugin-es": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-4.1.0.tgz",
-			"integrity": "sha512-GILhQTnjYE2WorX5Jyi5i4dz5ALWxBIdQECVQavL6s7cI76IZTDWleTHkxz/QT3kvcs2QlGHvKLYsSlPOlPXnQ==",
+		"node_modules/eslint-plugin-es-x": {
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-es-x/-/eslint-plugin-es-x-7.5.0.tgz",
+			"integrity": "sha512-ODswlDSO0HJDzXU0XvgZ3lF3lS3XAZEossh15Q2UHjwrJggWeBoKqqEsLTZLXl+dh5eOAozG0zRcYtuE35oTuQ==",
 			"dev": true,
 			"dependencies": {
-				"eslint-utils": "^2.0.0",
-				"regexpp": "^3.0.0"
+				"@eslint-community/eslint-utils": "^4.1.2",
+				"@eslint-community/regexpp": "^4.6.0",
+				"eslint-compat-utils": "^0.1.2"
 			},
 			"engines": {
-				"node": ">=8.10.0"
+				"node": "^14.18.0 || >=16.0.0"
 			},
 			"funding": {
-				"url": "https://github.com/sponsors/mysticatea"
+				"url": "https://github.com/sponsors/ota-meshi"
 			},
 			"peerDependencies": {
-				"eslint": ">=4.19.1"
-			}
-		},
-		"node_modules/eslint-plugin-es/node_modules/eslint-utils": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
-			"integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
-			"dev": true,
-			"dependencies": {
-				"eslint-visitor-keys": "^1.1.0"
-			},
-			"engines": {
-				"node": ">=6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/mysticatea"
-			}
-		},
-		"node_modules/eslint-plugin-es/node_modules/eslint-visitor-keys": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-			"integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=4"
+				"eslint": ">=8"
 			}
 		},
 		"node_modules/eslint-plugin-eslint-comments": {
@@ -2642,29 +2998,26 @@
 			}
 		},
 		"node_modules/eslint-plugin-import": {
-			"version": "2.28.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.28.0.tgz",
-			"integrity": "sha512-B8s/n+ZluN7sxj9eUf7/pRFERX0r5bnFA2dCaLHy2ZeaQEAz0k+ZZkFWRFHJAqxfxQDx6KLv9LeIki7cFdwW+Q==",
+			"version": "2.27.5",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.27.5.tgz",
+			"integrity": "sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==",
 			"dev": true,
 			"dependencies": {
 				"array-includes": "^3.1.6",
-				"array.prototype.findlastindex": "^1.2.2",
 				"array.prototype.flat": "^1.3.1",
 				"array.prototype.flatmap": "^1.3.1",
 				"debug": "^3.2.7",
 				"doctrine": "^2.1.0",
 				"eslint-import-resolver-node": "^0.3.7",
-				"eslint-module-utils": "^2.8.0",
+				"eslint-module-utils": "^2.7.4",
 				"has": "^1.0.3",
-				"is-core-module": "^2.12.1",
+				"is-core-module": "^2.11.0",
 				"is-glob": "^4.0.3",
 				"minimatch": "^3.1.2",
-				"object.fromentries": "^2.0.6",
-				"object.groupby": "^1.0.0",
 				"object.values": "^1.1.6",
-				"resolve": "^1.22.3",
-				"semver": "^6.3.1",
-				"tsconfig-paths": "^3.14.2"
+				"resolve": "^1.22.1",
+				"semver": "^6.3.0",
+				"tsconfig-paths": "^3.14.1"
 			},
 			"engines": {
 				"node": ">=4"
@@ -2694,6 +3047,23 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/eslint-plugin-import/node_modules/resolve": {
+			"version": "1.22.8",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+			"integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+			"dev": true,
+			"dependencies": {
+				"is-core-module": "^2.13.0",
+				"path-parse": "^1.0.7",
+				"supports-preserve-symlinks-flag": "^1.0.0"
+			},
+			"bin": {
+				"resolve": "bin/resolve"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/eslint-plugin-import/node_modules/semver": {
 			"version": "6.3.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -2704,28 +3074,47 @@
 			}
 		},
 		"node_modules/eslint-plugin-n": {
-			"version": "15.7.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-15.7.0.tgz",
-			"integrity": "sha512-jDex9s7D/Qial8AGVIHq4W7NswpUD5DPDL2RH8Lzd9EloWUuvUkHfv4FRLMipH5q2UtyurorBkPeNi1wVWNh3Q==",
+			"version": "16.3.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-16.3.1.tgz",
+			"integrity": "sha512-w46eDIkxQ2FaTHcey7G40eD+FhTXOdKudDXPUO2n9WNcslze/i/HT2qJ3GXjHngYSGDISIgPNhwGtgoix4zeOw==",
 			"dev": true,
 			"dependencies": {
+				"@eslint-community/eslint-utils": "^4.4.0",
 				"builtins": "^5.0.1",
-				"eslint-plugin-es": "^4.1.0",
-				"eslint-utils": "^3.0.0",
-				"ignore": "^5.1.1",
-				"is-core-module": "^2.11.0",
+				"eslint-plugin-es-x": "^7.1.0",
+				"get-tsconfig": "^4.7.0",
+				"ignore": "^5.2.4",
+				"is-builtin-module": "^3.2.1",
+				"is-core-module": "^2.12.1",
 				"minimatch": "^3.1.2",
-				"resolve": "^1.22.1",
-				"semver": "^7.3.8"
+				"resolve": "^1.22.2",
+				"semver": "^7.5.3"
 			},
 			"engines": {
-				"node": ">=12.22.0"
+				"node": ">=16.0.0"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/mysticatea"
 			},
 			"peerDependencies": {
 				"eslint": ">=7.0.0"
+			}
+		},
+		"node_modules/eslint-plugin-n/node_modules/resolve": {
+			"version": "1.22.8",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+			"integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+			"dev": true,
+			"dependencies": {
+				"is-core-module": "^2.13.0",
+				"path-parse": "^1.0.7",
+				"supports-preserve-symlinks-flag": "^1.0.0"
+			},
+			"bin": {
+				"resolve": "bin/resolve"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/eslint-plugin-no-use-extend-native": {
@@ -2744,57 +3133,64 @@
 			}
 		},
 		"node_modules/eslint-plugin-prettier": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz",
-			"integrity": "sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.0.1.tgz",
+			"integrity": "sha512-m3u5RnR56asrwV/lDC4GHorlW75DsFfmUcjfCYylTUs85dBRnB7VM6xG8eCMJdeDRnppzmxZVf1GEPJvl1JmNg==",
 			"dev": true,
 			"dependencies": {
-				"prettier-linter-helpers": "^1.0.0"
+				"prettier-linter-helpers": "^1.0.0",
+				"synckit": "^0.8.5"
 			},
 			"engines": {
-				"node": ">=12.0.0"
+				"node": "^14.18.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/prettier"
 			},
 			"peerDependencies": {
-				"eslint": ">=7.28.0",
-				"prettier": ">=2.0.0"
+				"@types/eslint": ">=8.0.0",
+				"eslint": ">=8.0.0",
+				"prettier": ">=3.0.0"
 			},
 			"peerDependenciesMeta": {
+				"@types/eslint": {
+					"optional": true
+				},
 				"eslint-config-prettier": {
 					"optional": true
 				}
 			}
 		},
 		"node_modules/eslint-plugin-unicorn": {
-			"version": "46.0.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-46.0.1.tgz",
-			"integrity": "sha512-setGhMTiLAddg1asdwjZ3hekIN5zLznNa5zll7pBPwFOka6greCKDQydfqy4fqyUhndi74wpDzClSQMEcmOaew==",
+			"version": "48.0.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-48.0.1.tgz",
+			"integrity": "sha512-FW+4r20myG/DqFcCSzoumaddKBicIPeFnTrifon2mWIzlfyvzwyqZjqVP7m4Cqr/ZYisS2aiLghkUWaPg6vtCw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.19.1",
-				"@eslint-community/eslint-utils": "^4.1.2",
-				"ci-info": "^3.6.1",
+				"@babel/helper-validator-identifier": "^7.22.5",
+				"@eslint-community/eslint-utils": "^4.4.0",
+				"ci-info": "^3.8.0",
 				"clean-regexp": "^1.0.0",
-				"esquery": "^1.4.0",
+				"esquery": "^1.5.0",
 				"indent-string": "^4.0.0",
-				"is-builtin-module": "^3.2.0",
+				"is-builtin-module": "^3.2.1",
 				"jsesc": "^3.0.2",
 				"lodash": "^4.17.21",
 				"pluralize": "^8.0.0",
 				"read-pkg-up": "^7.0.1",
-				"regexp-tree": "^0.1.24",
-				"regjsparser": "^0.9.1",
-				"safe-regex": "^2.1.1",
-				"semver": "^7.3.8",
+				"regexp-tree": "^0.1.27",
+				"regjsparser": "^0.10.0",
+				"semver": "^7.5.4",
 				"strip-indent": "^3.0.0"
 			},
 			"engines": {
-				"node": ">=14.18"
+				"node": ">=16"
 			},
 			"funding": {
 				"url": "https://github.com/sindresorhus/eslint-plugin-unicorn?sponsor=1"
 			},
 			"peerDependencies": {
-				"eslint": ">=8.28.0"
+				"eslint": ">=8.44.0"
 			}
 		},
 		"node_modules/eslint-plugin-unicorn/node_modules/indent-string": {
@@ -2856,33 +3252,10 @@
 			}
 		},
 		"node_modules/eslint-visitor-keys": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.2.tgz",
-			"integrity": "sha512-8drBzUEyZ2llkpCA67iYrgEssKDUu68V8ChqqOfFupIaG/LCVPUT+CoGJpT77zJprs4T/W7p07LP7zAIMuweVw==",
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+			"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
 			"dev": true,
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/eslint"
-			}
-		},
-		"node_modules/eslint/node_modules/@eslint/eslintrc": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.1.tgz",
-			"integrity": "sha512-9t7ZA7NGGK8ckelF0PQCfcxIUzs1Md5rrO6U/c+FIQNanea5UZC0wqKXH4vHBccmu4ZJgZ2idtPeW7+Q2npOEA==",
-			"dev": true,
-			"dependencies": {
-				"ajv": "^6.12.4",
-				"debug": "^4.3.2",
-				"espree": "^9.6.0",
-				"globals": "^13.19.0",
-				"ignore": "^5.2.0",
-				"import-fresh": "^3.2.1",
-				"js-yaml": "^4.1.0",
-				"minimatch": "^3.1.2",
-				"strip-json-comments": "^3.1.1"
-			},
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			},
@@ -3003,13 +3376,13 @@
 			}
 		},
 		"node_modules/esm-utils": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/esm-utils/-/esm-utils-4.1.2.tgz",
-			"integrity": "sha512-hYKPzOCkAU11rMIiH6gvvReARaSLiRhJkGWPcwJB/S4zg7em//YKAcRxwZYw4sW5mRmI6lhV59wWWTdWKwOXvQ==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/esm-utils/-/esm-utils-4.2.1.tgz",
+			"integrity": "sha512-a7t8pDmZ5MeYfo2pM5EcqeU+BqKobUFKnWkM17JOhTlR88OSosLa9Ak4bgm+htoF15HRf7tfrXNR62UogmIODg==",
 			"dev": true,
 			"dependencies": {
-				"import-meta-resolve": "2.2.2",
-				"url-or-path": "2.1.0"
+				"import-meta-resolve": "^4.0.0",
+				"url-or-path": "^2.1.0"
 			},
 			"funding": {
 				"url": "https://github.com/fisker/esm-utils?sponsor=1"
@@ -3174,14 +3547,14 @@
 			"dev": true
 		},
 		"node_modules/fast-fifo": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.0.tgz",
-			"integrity": "sha512-IgfweLvEpwyA4WgiQe9Nx6VV2QkML2NkvZnk1oKnIzXgXdWxuhF7zw4DvLTPZJn6PIUneiAXPF24QmoEqHTjyw=="
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+			"integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="
 		},
 		"node_modules/fast-glob": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
-			"integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+			"integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
 			"dev": true,
 			"dependencies": {
 				"@nodelib/fs.stat": "^2.0.2",
@@ -3224,16 +3597,16 @@
 			}
 		},
 		"node_modules/figures": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/figures/-/figures-4.0.1.tgz",
-			"integrity": "sha512-rElJwkA/xS04Vfg+CaZodpso7VqBknOYbzi6I76hI4X80RUjkSxO2oAyPmGbuXUppywjqndOrQDl817hDnI++w==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/figures/-/figures-5.0.0.tgz",
+			"integrity": "sha512-ej8ksPF4x6e5wvK9yevct0UCXh8TTFlWGVLlgjZuoBH1HwjIfKE/IdL5mq89sFA7zELi1VhKpmtDnrs7zWyeyg==",
 			"dev": true,
 			"dependencies": {
 				"escape-string-regexp": "^5.0.0",
 				"is-unicode-supported": "^1.2.0"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=14"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -3252,9 +3625,9 @@
 			}
 		},
 		"node_modules/file-type": {
-			"version": "18.5.0",
-			"resolved": "https://registry.npmjs.org/file-type/-/file-type-18.5.0.tgz",
-			"integrity": "sha512-yvpl5U868+V6PqXHMmsESpg6unQ5GfnPssl4dxdJudBrr9qy7Fddt7EVX1VLlddFfe8Gj9N7goCZH22FXuSQXQ==",
+			"version": "18.7.0",
+			"resolved": "https://registry.npmjs.org/file-type/-/file-type-18.7.0.tgz",
+			"integrity": "sha512-ihHtXRzXEziMrQ56VSgU7wkxh55iNchFkosu7Y9/S+tXHdKyrGjVK0ujbqNnsxzea+78MaLhN6PGmfYSAv1ACw==",
 			"dependencies": {
 				"readable-web-to-node-stream": "^3.0.2",
 				"strtok3": "^7.0.0",
@@ -3279,16 +3652,14 @@
 			}
 		},
 		"node_modules/filenamify": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/filenamify/-/filenamify-5.1.1.tgz",
-			"integrity": "sha512-M45CbrJLGACfrPOkrTp3j2EcO9OBkKUYME0eiqOCa7i2poaklU0jhlIaMlr8ijLorT0uLAzrn3qXOp5684CkfA==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/filenamify/-/filenamify-6.0.0.tgz",
+			"integrity": "sha512-vqIlNogKeyD3yzrm0yhRMQg8hOVwYcYRfjEoODd49iCprMn4HL85gK3HcykQE53EPIpX3HcAbGA5ELQv216dAQ==",
 			"dependencies": {
-				"filename-reserved-regex": "^3.0.0",
-				"strip-outer": "^2.0.0",
-				"trim-repeated": "^2.0.0"
+				"filename-reserved-regex": "^3.0.0"
 			},
 			"engines": {
-				"node": ">=12.20"
+				"node": ">=16"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -3442,12 +3813,13 @@
 			}
 		},
 		"node_modules/flat-cache": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
-			"integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
+			"integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
 			"dev": true,
 			"dependencies": {
-				"flatted": "^3.1.0",
+				"flatted": "^3.2.9",
+				"keyv": "^4.5.3",
 				"rimraf": "^3.0.2"
 			},
 			"engines": {
@@ -3455,9 +3827,9 @@
 			}
 		},
 		"node_modules/flatted": {
-			"version": "3.2.7",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
-			"integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
+			"version": "3.2.9",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.9.tgz",
+			"integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==",
 			"dev": true
 		},
 		"node_modules/for-each": {
@@ -3497,9 +3869,9 @@
 			"dev": true
 		},
 		"node_modules/fsevents": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
 			"dev": true,
 			"hasInstallScript": true,
 			"optional": true,
@@ -3511,21 +3883,24 @@
 			}
 		},
 		"node_modules/function-bind": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-			"dev": true
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+			"dev": true,
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/function.prototype.name": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
-			"integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.6.tgz",
+			"integrity": "sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==",
 			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.19.0",
-				"functions-have-names": "^1.2.2"
+				"define-properties": "^1.2.0",
+				"es-abstract": "^1.22.1",
+				"functions-have-names": "^1.2.3"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -3553,15 +3928,15 @@
 			}
 		},
 		"node_modules/get-intrinsic": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
-			"integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.2.tgz",
+			"integrity": "sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==",
 			"dev": true,
 			"dependencies": {
-				"function-bind": "^1.1.1",
-				"has": "^1.0.3",
+				"function-bind": "^1.1.2",
 				"has-proto": "^1.0.1",
-				"has-symbols": "^1.0.3"
+				"has-symbols": "^1.0.3",
+				"hasown": "^2.0.0"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -3616,9 +3991,9 @@
 			}
 		},
 		"node_modules/get-tsconfig": {
-			"version": "4.6.2",
-			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.6.2.tgz",
-			"integrity": "sha512-E5XrT4CbbXcXWy+1jChlZmrmCwd5KGx502kDCXJJ7y898TtWW9FwoG5HfOLVRKmlmDGkWN2HM9Ho+/Y8F0sJDg==",
+			"version": "4.7.2",
+			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.7.2.tgz",
+			"integrity": "sha512-wuMsz4leaj5hbGgg4IvDU0bqJagpftG5l5cXIAvo8uZrqn0NJqwtfupTN00VnkQJPcIRrxYrm1Ue24btpCha2A==",
 			"dev": true,
 			"dependencies": {
 				"resolve-pkg-maps": "^1.0.0"
@@ -3667,9 +4042,9 @@
 			"peer": true
 		},
 		"node_modules/globals": {
-			"version": "13.20.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
-			"integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
+			"version": "13.23.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-13.23.0.tgz",
+			"integrity": "sha512-XAmF0RjlrjY23MA51q3HltdlGxUpXPvg0GioKiD9X6HD28iMjo2dKC8Vqwm7lne4GNr78+RHTfliktR6ZH09wA==",
 			"dev": true,
 			"dependencies": {
 				"type-fest": "^0.20.2"
@@ -3727,18 +4102,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/globby/node_modules/slash": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
-			"integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
-			"dev": true,
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/gopd": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
@@ -3752,9 +4115,9 @@
 			}
 		},
 		"node_modules/got": {
-			"version": "12.6.1",
-			"resolved": "https://registry.npmjs.org/got/-/got-12.6.1.tgz",
-			"integrity": "sha512-mThBblvlAF1d4O5oqyvN+ZxLAYwIJK7bpMxgYqPD9okW0C3qm5FFn7k811QrcuEBwaogR3ngOFoCfs6mRv7teQ==",
+			"version": "13.0.0",
+			"resolved": "https://registry.npmjs.org/got/-/got-13.0.0.tgz",
+			"integrity": "sha512-XfBk1CxOOScDcMr9O1yKkNaQyy865NbYs+F7dr4H0LZMVgCj2Le59k6PqbNHoL5ToeaEQUYh6c6yMfVcc6SJxA==",
 			"dependencies": {
 				"@sindresorhus/is": "^5.2.0",
 				"@szmarczak/http-timer": "^5.0.1",
@@ -3769,7 +4132,7 @@
 				"responselike": "^3.0.0"
 			},
 			"engines": {
-				"node": ">=14.16"
+				"node": ">=16"
 			},
 			"funding": {
 				"url": "https://github.com/sindresorhus/got?sponsor=1"
@@ -3786,23 +4149,11 @@
 			"integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
 			"dev": true
 		},
-		"node_modules/hard-rejection": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
-			"integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/has": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/has/-/has-1.0.4.tgz",
+			"integrity": "sha512-qdSAmqLF6209RFj4VVItywPMbm3vWylknmB3nvNiUIs72xAimcM8nVYxYr7ncvZq5qzk9MKIZR8ijqD/1QuYjQ==",
 			"dev": true,
-			"dependencies": {
-				"function-bind": "^1.1.1"
-			},
 			"engines": {
 				"node": ">= 0.4.0"
 			}
@@ -3826,12 +4177,12 @@
 			}
 		},
 		"node_modules/has-property-descriptors": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
-			"integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz",
+			"integrity": "sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==",
 			"dev": true,
 			"dependencies": {
-				"get-intrinsic": "^1.1.1"
+				"get-intrinsic": "^1.2.2"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -3876,26 +4227,23 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/hosted-git-info": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-5.2.1.tgz",
-			"integrity": "sha512-xIcQYMnhcx2Nr4JTjsFmwwnr9vldugPy9uVm0o87bjqqWMv9GaqsTeT+i99wTl0mk1uLxJtHxLb8kymqTENQsw==",
+		"node_modules/hasown": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
+			"integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
 			"dev": true,
 			"dependencies": {
-				"lru-cache": "^7.5.1"
+				"function-bind": "^1.1.2"
 			},
 			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+				"node": ">= 0.4"
 			}
 		},
-		"node_modules/hosted-git-info/node_modules/lru-cache": {
-			"version": "7.18.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-			"integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-			"dev": true,
-			"engines": {
-				"node": ">=12"
-			}
+		"node_modules/hosted-git-info": {
+			"version": "2.8.9",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+			"integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+			"dev": true
 		},
 		"node_modules/html-escaper": {
 			"version": "2.0.2",
@@ -3909,9 +4257,9 @@
 			"integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
 		},
 		"node_modules/http2-wrapper": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.0.tgz",
-			"integrity": "sha512-kZB0wxMo0sh1PehyjJUWRFEd99KC5TLjZ2cULC4f9iqJBAmKQQXEICjxl5iPJRwP40dpeHFqqhm7tYCvODpqpQ==",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.1.tgz",
+			"integrity": "sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==",
 			"dependencies": {
 				"quick-lru": "^5.1.1",
 				"resolve-alpn": "^1.2.0"
@@ -3949,9 +4297,9 @@
 			]
 		},
 		"node_modules/ignore": {
-			"version": "5.2.4",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
-			"integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.0.tgz",
+			"integrity": "sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==",
 			"dev": true,
 			"engines": {
 				"node": ">= 4"
@@ -3992,9 +4340,9 @@
 			}
 		},
 		"node_modules/import-meta-resolve": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-2.2.2.tgz",
-			"integrity": "sha512-f8KcQ1D80V7RnqVm+/lirO9zkOxjGxhaTC1IPrBGd3MEfNgmNG67tSUO9gTi2F3Blr2Az6g1vocaxzkVnWl9MA==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.0.0.tgz",
+			"integrity": "sha512-okYUR7ZQPH+efeuMJGlq4f8ubUgO50kByRPyt/Cy1Io4PSRsPjxME+YlVaCOx+NIToW7hCsZNFJyTPFFKepRSA==",
 			"dev": true,
 			"funding": {
 				"type": "github",
@@ -4058,13 +4406,13 @@
 			}
 		},
 		"node_modules/internal-slot": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.5.tgz",
-			"integrity": "sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.6.tgz",
+			"integrity": "sha512-Xj6dv+PsbtwyPpEflsejS+oIZxmMlV44zAhG479uYu89MsjcYOhCFnNyKrkJrihbsiasQyY0afoCl/9BLR65bg==",
 			"dev": true,
 			"dependencies": {
-				"get-intrinsic": "^1.2.0",
-				"has": "^1.0.3",
+				"get-intrinsic": "^1.2.2",
+				"hasown": "^2.0.0",
 				"side-channel": "^1.0.4"
 			},
 			"engines": {
@@ -4190,12 +4538,12 @@
 			}
 		},
 		"node_modules/is-core-module": {
-			"version": "2.12.1",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.1.tgz",
-			"integrity": "sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==",
+			"version": "2.13.1",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
+			"integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
 			"dev": true,
 			"dependencies": {
-				"has": "^1.0.3"
+				"hasown": "^2.0.0"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -4289,6 +4637,39 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/is-inside-container": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+			"integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+			"dev": true,
+			"dependencies": {
+				"is-docker": "^3.0.0"
+			},
+			"bin": {
+				"is-inside-container": "cli.js"
+			},
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/is-inside-container/node_modules/is-docker": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+			"integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+			"dev": true,
+			"bin": {
+				"is-docker": "cli.js"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/is-js-type": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-js-type/-/is-js-type-2.0.0.tgz",
@@ -4362,15 +4743,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/is-path-cwd": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
-			"integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/is-path-inside": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
@@ -4378,6 +4750,14 @@
 			"dev": true,
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/is-plain-obj": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+			"integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/is-plain-object": {
@@ -4589,9 +4969,9 @@
 			"dev": true
 		},
 		"node_modules/istanbul-lib-coverage": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz",
-			"integrity": "sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==",
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+			"integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
 			"dev": true,
 			"engines": {
 				"node": ">=8"
@@ -4746,9 +5126,9 @@
 			}
 		},
 		"node_modules/keyv": {
-			"version": "4.5.3",
-			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.3.tgz",
-			"integrity": "sha512-QCiSav9WaX1PgETJ+SpNnx2PRRapJ/oRSXM4VO5OGYGSjrxbKPVFVhB3l2OCbLCk329N8qyAtsJjSjvVBWzEug==",
+			"version": "4.5.4",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+			"integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
 			"dependencies": {
 				"json-buffer": "3.0.1"
 			}
@@ -4987,18 +5367,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/map-obj": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
-			"integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/matcher": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/matcher/-/matcher-5.0.0.tgz",
@@ -5049,197 +5417,12 @@
 			"dev": true
 		},
 		"node_modules/meow": {
-			"version": "11.0.0",
-			"resolved": "https://registry.npmjs.org/meow/-/meow-11.0.0.tgz",
-			"integrity": "sha512-Cl0yeeIrko6d94KpUo1M+0X1sB14ikoaqlIGuTH1fW4I+E3+YljL54/hb/BWmVfrV9tTV9zU04+xjw08Fh2WkA==",
-			"dev": true,
-			"dependencies": {
-				"@types/minimist": "^1.2.2",
-				"camelcase-keys": "^8.0.2",
-				"decamelize": "^6.0.0",
-				"decamelize-keys": "^1.1.0",
-				"hard-rejection": "^2.1.0",
-				"minimist-options": "4.1.0",
-				"normalize-package-data": "^4.0.1",
-				"read-pkg-up": "^9.1.0",
-				"redent": "^4.0.0",
-				"trim-newlines": "^4.0.2",
-				"type-fest": "^3.1.0",
-				"yargs-parser": "^21.1.1"
-			},
-			"engines": {
-				"node": ">=14.16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/meow/node_modules/find-up": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-6.3.0.tgz",
-			"integrity": "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==",
-			"dev": true,
-			"dependencies": {
-				"locate-path": "^7.1.0",
-				"path-exists": "^5.0.0"
-			},
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/meow/node_modules/hosted-git-info": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
-			"integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
-			"dev": true,
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/meow/node_modules/locate-path": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
-			"integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
-			"dev": true,
-			"dependencies": {
-				"p-locate": "^6.0.0"
-			},
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/meow/node_modules/p-limit": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
-			"integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
-			"dev": true,
-			"dependencies": {
-				"yocto-queue": "^1.0.0"
-			},
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/meow/node_modules/p-locate": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
-			"integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
-			"dev": true,
-			"dependencies": {
-				"p-limit": "^4.0.0"
-			},
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/meow/node_modules/read-pkg": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-7.1.0.tgz",
-			"integrity": "sha512-5iOehe+WF75IccPc30bWTbpdDQLOCc3Uu8bi3Dte3Eueij81yx1Mrufk8qBx/YAbR4uL1FdUr+7BKXDwEtisXg==",
-			"dev": true,
-			"dependencies": {
-				"@types/normalize-package-data": "^2.4.1",
-				"normalize-package-data": "^3.0.2",
-				"parse-json": "^5.2.0",
-				"type-fest": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=12.20"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/meow/node_modules/read-pkg-up": {
-			"version": "9.1.0",
-			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-9.1.0.tgz",
-			"integrity": "sha512-vaMRR1AC1nrd5CQM0PhlRsO5oc2AAigqr7cCrZ/MW/Rsaflz4RlgzkpL4qoU/z1F6wrbd85iFv1OQj/y5RdGvg==",
-			"dev": true,
-			"dependencies": {
-				"find-up": "^6.3.0",
-				"read-pkg": "^7.1.0",
-				"type-fest": "^2.5.0"
-			},
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/meow/node_modules/read-pkg-up/node_modules/type-fest": {
-			"version": "2.19.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-			"integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+			"version": "12.1.1",
+			"resolved": "https://registry.npmjs.org/meow/-/meow-12.1.1.tgz",
+			"integrity": "sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==",
 			"dev": true,
 			"engines": {
-				"node": ">=12.20"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/meow/node_modules/read-pkg/node_modules/normalize-package-data": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
-			"integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
-			"dev": true,
-			"dependencies": {
-				"hosted-git-info": "^4.0.1",
-				"is-core-module": "^2.5.0",
-				"semver": "^7.3.4",
-				"validate-npm-package-license": "^3.0.1"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/meow/node_modules/read-pkg/node_modules/type-fest": {
-			"version": "2.19.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-			"integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-			"dev": true,
-			"engines": {
-				"node": ">=12.20"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/meow/node_modules/type-fest": {
-			"version": "3.13.1",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
-			"integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==",
-			"dev": true,
-			"engines": {
-				"node": ">=14.16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/meow/node_modules/yocto-queue": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
-			"integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
-			"dev": true,
-			"engines": {
-				"node": ">=12.20"
+				"node": ">=16.10"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -5353,38 +5536,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/minimist-options": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
-			"integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
-			"dev": true,
-			"dependencies": {
-				"arrify": "^1.0.1",
-				"is-plain-obj": "^1.1.0",
-				"kind-of": "^6.0.3"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
-		"node_modules/minimist-options/node_modules/arrify": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-			"integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/minimist-options/node_modules/is-plain-obj": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-			"integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/ms": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -5405,14 +5556,13 @@
 			"peer": true
 		},
 		"node_modules/nock": {
-			"version": "13.3.2",
-			"resolved": "https://registry.npmjs.org/nock/-/nock-13.3.2.tgz",
-			"integrity": "sha512-CwbljitiWJhF1gL83NbanhoKs1l23TDlRioNraPTZrzZIEooPemrHRj5m0FZCPkB1ecdYCSWWGcHysJgX/ngnQ==",
+			"version": "13.4.0",
+			"resolved": "https://registry.npmjs.org/nock/-/nock-13.4.0.tgz",
+			"integrity": "sha512-W8NVHjO/LCTNA64yxAPHV/K47LpGYcVzgKd3Q0n6owhwvD0Dgoterc25R4rnZbckJEb6Loxz1f5QMuJpJnbSyQ==",
 			"dev": true,
 			"dependencies": {
 				"debug": "^4.1.0",
 				"json-stringify-safe": "^5.0.1",
-				"lodash": "^4.17.21",
 				"propagate": "^2.0.0"
 			},
 			"engines": {
@@ -5420,9 +5570,9 @@
 			}
 		},
 		"node_modules/node-releases": {
-			"version": "2.0.13",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
-			"integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
+			"version": "2.0.14",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
+			"integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
 			"dev": true,
 			"peer": true
 		},
@@ -5436,18 +5586,41 @@
 			}
 		},
 		"node_modules/normalize-package-data": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-4.0.1.tgz",
-			"integrity": "sha512-EBk5QKKuocMJhB3BILuKhmaPjI8vNRSpIfO9woLC6NyHVkKKdVEdAO1mrT0ZfxNR1lKwCcTkuZfmGIFdizZ8Pg==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+			"integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
 			"dev": true,
 			"dependencies": {
-				"hosted-git-info": "^5.0.0",
-				"is-core-module": "^2.8.1",
-				"semver": "^7.3.5",
-				"validate-npm-package-license": "^3.0.4"
+				"hosted-git-info": "^2.1.4",
+				"resolve": "^1.10.0",
+				"semver": "2 || 3 || 4 || 5",
+				"validate-npm-package-license": "^3.0.1"
+			}
+		},
+		"node_modules/normalize-package-data/node_modules/resolve": {
+			"version": "1.22.8",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+			"integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+			"dev": true,
+			"dependencies": {
+				"is-core-module": "^2.13.0",
+				"path-parse": "^1.0.7",
+				"supports-preserve-symlinks-flag": "^1.0.0"
 			},
-			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+			"bin": {
+				"resolve": "bin/resolve"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/normalize-package-data/node_modules/semver": {
+			"version": "5.7.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+			"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver"
 			}
 		},
 		"node_modules/normalize-path": {
@@ -5492,9 +5665,9 @@
 			}
 		},
 		"node_modules/object-inspect": {
-			"version": "1.12.3",
-			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
-			"integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
+			"version": "1.13.1",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
+			"integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
 			"dev": true,
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -5510,13 +5683,13 @@
 			}
 		},
 		"node_modules/object.assign": {
-			"version": "4.1.4",
-			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
-			"integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.5.tgz",
+			"integrity": "sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==",
 			"dev": true,
 			"dependencies": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.4",
+				"call-bind": "^1.0.5",
+				"define-properties": "^1.2.1",
 				"has-symbols": "^1.0.3",
 				"object-keys": "^1.1.1"
 			},
@@ -5527,44 +5700,15 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/object.fromentries": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.6.tgz",
-			"integrity": "sha512-VciD13dswC4j1Xt5394WR4MzmAQmlgN72phd/riNp9vtD7tp4QQWJ0R4wvclXcafgcYK8veHRed2W6XeGBvcfg==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.4",
-				"es-abstract": "^1.20.4"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/object.groupby": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.0.tgz",
-			"integrity": "sha512-70MWG6NfRH9GnbZOikuhPPYzpUpof9iW2J9E4dW7FXTqPNb6rllE6u39SKwwiNh8lCwX3DDb5OgcKGiEBrTTyw==",
+		"node_modules/object.values": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.7.tgz",
+			"integrity": "sha512-aU6xnDFYT3x17e/f0IiiwlGPTy2jzMySGfUB4fq6z7CV8l85CWHDk5ErhyhpfDHhrOMwGFhSQkhMGHaIotA6Ng==",
 			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.2.0",
-				"es-abstract": "^1.21.2",
-				"get-intrinsic": "^1.2.1"
-			}
-		},
-		"node_modules/object.values": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.6.tgz",
-			"integrity": "sha512-FVVTkD1vENCsAcwNs9k6jea2uHC/X0+JcjG8YA60FN5CMaJmG95wT9jek/xX9nornqGRrBkKtzuAu2wuHpKqvw==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.4",
-				"es-abstract": "^1.20.4"
+				"es-abstract": "^1.22.1"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -5624,12 +5768,12 @@
 			}
 		},
 		"node_modules/open-editor": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/open-editor/-/open-editor-4.0.0.tgz",
-			"integrity": "sha512-5mKZ98iFdkivozt5XTCOspoKbL3wtYu6oOoVxfWQ0qUX9NYsK8pdkHE7VUHXr+CwyC3nf6mV0S5FPsMS65innw==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/open-editor/-/open-editor-4.1.1.tgz",
+			"integrity": "sha512-SYtGeZ9Zkzj/naoZaEF9LzwDYEGwuqQ4Fx5E3xdVRN98LFJjvMhG/ElByFEOVOiXepGra/Wi1fA4i/E1fXSBsw==",
 			"dev": true,
 			"dependencies": {
-				"env-editor": "^1.0.0",
+				"env-editor": "^1.1.0",
 				"execa": "^5.1.1",
 				"line-column-path": "^3.0.0",
 				"open": "^8.4.0"
@@ -5685,14 +5829,14 @@
 			}
 		},
 		"node_modules/p-event": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/p-event/-/p-event-5.0.1.tgz",
-			"integrity": "sha512-dd589iCQ7m1L0bmC5NLlVYfy3TbBEsMUfWx9PyAgPeIcFZ/E2yaTZ4Rz4MiBmmJShviiftHVXOqfnfzJ6kyMrQ==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/p-event/-/p-event-6.0.0.tgz",
+			"integrity": "sha512-Xbfxd0CfZmHLGKXH32k1JKjQYX6Rkv0UtQdaFJ8OyNcf+c0oWCeXHc1C4CX/IESZLmcvfPa5aFIO/vCr5gqtag==",
 			"dependencies": {
-				"p-timeout": "^5.0.2"
+				"p-timeout": "^6.1.2"
 			},
 			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+				"node": ">=16.17"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -5744,11 +5888,11 @@
 			}
 		},
 		"node_modules/p-timeout": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-5.1.0.tgz",
-			"integrity": "sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew==",
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.2.tgz",
+			"integrity": "sha512-UbD77BuZ9Bc9aABo74gfXhNvzC9Tx7SxtHSh1fxvx3jTLLYvmVhiQZZrJzqqU0jKbN32kb5VOKiLEQI/3bIjgQ==",
 			"engines": {
-				"node": ">=12"
+				"node": ">=14.16"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -5803,12 +5947,15 @@
 			}
 		},
 		"node_modules/parse-ms": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-2.1.0.tgz",
-			"integrity": "sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-3.0.0.tgz",
+			"integrity": "sha512-Tpb8Z7r7XbbtBTrM9UhpkzzaMrqA2VXMT3YChzYltwV3P3pM6t8wl7TvpMnSTosz1aQAdVib7kdoys7vYOPerw==",
 			"dev": true,
 			"engines": {
-				"node": ">=6"
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/path-exists": {
@@ -5874,8 +6021,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
 			"integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/picomatch": {
 			"version": "2.3.1",
@@ -6024,15 +6170,15 @@
 			}
 		},
 		"node_modules/prettier": {
-			"version": "2.8.8",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-			"integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.0.tgz",
+			"integrity": "sha512-TQLvXjq5IAibjh8EpBIkNKxO749UEWABoiIZehEPiY4GNpVdhaFKqSTu+QrlU6D2dPAfubRmtJTi4K4YkQ5eXw==",
 			"dev": true,
 			"bin": {
-				"prettier": "bin-prettier.js"
+				"prettier": "bin/prettier.cjs"
 			},
 			"engines": {
-				"node": ">=10.13.0"
+				"node": ">=14"
 			},
 			"funding": {
 				"url": "https://github.com/prettier/prettier?sponsor=1"
@@ -6051,15 +6197,15 @@
 			}
 		},
 		"node_modules/pretty-ms": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-7.0.1.tgz",
-			"integrity": "sha512-973driJZvxiGOQ5ONsFhOF/DtzPMOMtgC11kCpUrPGMTgqp2q/1gwzCquocrN33is0VZ5GFHXZYMM9l6h67v2Q==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-8.0.0.tgz",
+			"integrity": "sha512-ASJqOugUF1bbzI35STMBUpZqdfYKlJugy6JBziGi2EE+AL5JPJGSzvpeVXojxrr0ViUYoToUjb5kjSEGf7Y83Q==",
 			"dev": true,
 			"dependencies": {
-				"parse-ms": "^2.1.0"
+				"parse-ms": "^3.0.0"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=14.16"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -6084,9 +6230,9 @@
 			}
 		},
 		"node_modules/punycode": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-			"integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
 			"dev": true,
 			"engines": {
 				"node": ">=6"
@@ -6240,33 +6386,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/read-pkg/node_modules/hosted-git-info": {
-			"version": "2.8.9",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-			"integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
-			"dev": true
-		},
-		"node_modules/read-pkg/node_modules/normalize-package-data": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-			"integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-			"dev": true,
-			"dependencies": {
-				"hosted-git-info": "^2.1.4",
-				"resolve": "^1.10.0",
-				"semver": "2 || 3 || 4 || 5",
-				"validate-npm-package-license": "^3.0.1"
-			}
-		},
-		"node_modules/read-pkg/node_modules/semver": {
-			"version": "5.7.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-			"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-			"dev": true,
-			"bin": {
-				"semver": "bin/semver"
-			}
-		},
 		"node_modules/read-pkg/node_modules/type-fest": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
@@ -6316,37 +6435,6 @@
 				"node": ">=8.10.0"
 			}
 		},
-		"node_modules/redent": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/redent/-/redent-4.0.0.tgz",
-			"integrity": "sha512-tYkDkVVtYkSVhuQ4zBgfvciymHaeuel+zFKXShfDnFP5SyVEP7qo70Rf1jTOTCx3vGNAbnEi/xFkcfQVMIBWag==",
-			"dev": true,
-			"dependencies": {
-				"indent-string": "^5.0.0",
-				"strip-indent": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/redent/node_modules/strip-indent": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.0.0.tgz",
-			"integrity": "sha512-mnVSV2l+Zv6BLpSD/8V87CW/y9EmmbYzGCIavsnsI6/nwn26DwffM/yztm30Z/I2DY9wdS3vXVCMnHDgZaVNoA==",
-			"dev": true,
-			"dependencies": {
-				"min-indent": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/regexp-tree": {
 			"version": "0.1.27",
 			"resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
@@ -6357,14 +6445,14 @@
 			}
 		},
 		"node_modules/regexp.prototype.flags": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.0.tgz",
-			"integrity": "sha512-0SutC3pNudRKgquxGoRGIz946MZVHqbNfPjBdxeOhBrdgDKlRoXmYLQN9xRbrR09ZXWeGAdPuif7egofn6v5LA==",
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.1.tgz",
+			"integrity": "sha512-sy6TXMN+hnP/wMy+ISxg3krXx7BAtWVO4UouuCN/ziM9UEne0euamVNafDfvC83bRNr95y0V5iijeDQFUNpvrg==",
 			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.2.0",
-				"functions-have-names": "^1.2.3"
+				"set-function-name": "^2.0.0"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -6373,22 +6461,10 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/regexpp": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
-			"integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/mysticatea"
-			}
-		},
 		"node_modules/regjsparser": {
-			"version": "0.9.1",
-			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.9.1.tgz",
-			"integrity": "sha512-dQUtn90WanSNl+7mQKcXAgZxvUe7Z0SqXlgzv0za4LwiUhyzBC58yQO3liFoUgu8GiJVInAhJjkj1N0EtQ5nkQ==",
+			"version": "0.10.0",
+			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.10.0.tgz",
+			"integrity": "sha512-qx+xQGZVsy55CH0a1hiVwHmqjLryfh7wQyF5HO07XJ9f7dQMY/gPQHhlyDkIzJKC+x2fUCpCcUODUUUFrm7SHA==",
 			"dev": true,
 			"dependencies": {
 				"jsesc": "~0.5.0"
@@ -6416,12 +6492,12 @@
 			}
 		},
 		"node_modules/resolve": {
-			"version": "1.22.3",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.3.tgz",
-			"integrity": "sha512-P8ur/gp/AmbEzjr729bZnLjXK5Z+4P0zhIJgBgzqRih7hL7BOukHGtSTA3ACMY467GRFz3duQsi0bDZdR7DKdw==",
+			"version": "2.0.0-next.5",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.5.tgz",
+			"integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
 			"dev": true,
 			"dependencies": {
-				"is-core-module": "^2.12.0",
+				"is-core-module": "^2.13.0",
 				"path-parse": "^1.0.7",
 				"supports-preserve-symlinks-flag": "^1.0.0"
 			},
@@ -6506,6 +6582,21 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
+		"node_modules/run-applescript": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-5.0.0.tgz",
+			"integrity": "sha512-XcT5rBksx1QdIhlFOCtgZkB99ZEouFZ1E2Kc2LHqNW13U3/74YGdkQRmThTwxy4QIyookibDKYZOPqX//6BlAg==",
+			"dev": true,
+			"dependencies": {
+				"execa": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/run-parallel": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -6530,13 +6621,13 @@
 			}
 		},
 		"node_modules/safe-array-concat": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.0.0.tgz",
-			"integrity": "sha512-9dVEFruWIsnie89yym+xWTAYASdpw3CJV7Li/6zBewGf9z2i1j31rP6jnY0pHEO4QZh6N0K11bFjWmdR8UGdPQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.0.1.tgz",
+			"integrity": "sha512-6XbUAseYE2KtOuGueyeobCySj9L4+66Tn6KQMOPQJrAJEowYKW/YR/MGJZl7FdydUdaFu4LYyDZjxf4/Nmo23Q==",
 			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
-				"get-intrinsic": "^1.2.0",
+				"get-intrinsic": "^1.2.1",
 				"has-symbols": "^1.0.3",
 				"isarray": "^2.0.5"
 			},
@@ -6565,15 +6656,6 @@
 					"url": "https://feross.org/support"
 				}
 			]
-		},
-		"node_modules/safe-regex": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz",
-			"integrity": "sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==",
-			"dev": true,
-			"dependencies": {
-				"regexp-tree": "~0.1.1"
-			}
 		},
 		"node_modules/safe-regex-test": {
 			"version": "1.0.0",
@@ -6659,6 +6741,35 @@
 				"randombytes": "^2.1.0"
 			}
 		},
+		"node_modules/set-function-length": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.1.1.tgz",
+			"integrity": "sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==",
+			"dev": true,
+			"dependencies": {
+				"define-data-property": "^1.1.1",
+				"get-intrinsic": "^1.2.1",
+				"gopd": "^1.0.1",
+				"has-property-descriptors": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/set-function-name": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.1.tgz",
+			"integrity": "sha512-tMNCiqYVkXIZgc2Hnoy2IvC/f8ezc5koaRFkCjrpWzGpCd3qbZXPzVy9MAZzK1ch/X0jvSkojys3oqJN0qCmdA==",
+			"dev": true,
+			"dependencies": {
+				"define-data-property": "^1.0.1",
+				"functions-have-names": "^1.2.3",
+				"has-property-descriptors": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/shebang-command": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -6701,12 +6812,15 @@
 			"dev": true
 		},
 		"node_modules/slash": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+			"integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
 			"dev": true,
 			"engines": {
-				"node": ">=8"
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/slice-ansi": {
@@ -6743,14 +6857,6 @@
 			"dependencies": {
 				"sort-keys": "^1.0.0"
 			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/sort-keys/node_modules/is-plain-obj": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-			"integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -6803,9 +6909,9 @@
 			}
 		},
 		"node_modules/spdx-license-ids": {
-			"version": "3.0.13",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.13.tgz",
-			"integrity": "sha512-XkD+zwiqXHikFZm4AX/7JSCXA98U5Db4AFd5XUg/+9UNtnH75+Z9KxtpYiJZx36mUDVOwH83pl7yvCer6ewM3w==",
+			"version": "3.0.16",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.16.tgz",
+			"integrity": "sha512-eWN+LnM3GR6gPu35WxNgbGl8rmY1AEmoMDvL/QD6zYmPWgywxWqJWNdLGT+ke8dKNWrcYgYjPpG5gbTfghP8rw==",
 			"dev": true
 		},
 		"node_modules/sprintf-js": {
@@ -6836,9 +6942,9 @@
 			}
 		},
 		"node_modules/streamx": {
-			"version": "2.15.0",
-			"resolved": "https://registry.npmjs.org/streamx/-/streamx-2.15.0.tgz",
-			"integrity": "sha512-HcxY6ncGjjklGs1xsP1aR71INYcsXFJet5CU1CHqihQ2J5nOsbd4OjgjHO42w/4QNv9gZb3BueV+Vxok5pLEXg==",
+			"version": "2.15.6",
+			"resolved": "https://registry.npmjs.org/streamx/-/streamx-2.15.6.tgz",
+			"integrity": "sha512-q+vQL4AAz+FdfT137VF69Cc/APqUbxy+MDOImRrMvchJpigHj9GksgDU2LYbO9rx7RX6osWgxJB2WxhYv4SZAw==",
 			"dependencies": {
 				"fast-fifo": "^1.1.0",
 				"queue-tick": "^1.0.1"
@@ -6870,14 +6976,14 @@
 			}
 		},
 		"node_modules/string.prototype.trim": {
-			"version": "1.2.7",
-			"resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.7.tgz",
-			"integrity": "sha512-p6TmeT1T3411M8Cgg9wBTMRtY2q9+PNy9EV1i2lIXUN/btt763oIfxwN3RR8VU6wHX8j/1CFy0L+YuThm6bgOg==",
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.8.tgz",
+			"integrity": "sha512-lfjY4HcixfQXOfaqCvcBuOIapyaroTXhbkfJN3gcB1OtyupngWK4sEET9Knd0cXd28kTUqu/kHoV4HKSJdnjiQ==",
 			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.4",
-				"es-abstract": "^1.20.4"
+				"define-properties": "^1.2.0",
+				"es-abstract": "^1.22.1"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -6887,28 +6993,28 @@
 			}
 		},
 		"node_modules/string.prototype.trimend": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz",
-			"integrity": "sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.7.tgz",
+			"integrity": "sha512-Ni79DqeB72ZFq1uH/L6zJ+DKZTkOtPIHovb3YZHQViE+HDouuU4mBrLOLDn5Dde3RF8qw5qVETEjhu9locMLvA==",
 			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.4",
-				"es-abstract": "^1.20.4"
+				"define-properties": "^1.2.0",
+				"es-abstract": "^1.22.1"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/string.prototype.trimstart": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.6.tgz",
-			"integrity": "sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.7.tgz",
+			"integrity": "sha512-NGhtDFu3jCEm7B4Fy0DpLewdJQOZcQ0rGbwQ/+stjnrp2i+rlKeCvos9hOIeCmqwratM47OBxY7uFZzjxHXmrg==",
 			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.4",
-				"es-abstract": "^1.20.4"
+				"define-properties": "^1.2.0",
+				"es-abstract": "^1.22.1"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -6947,14 +7053,6 @@
 				"is-plain-obj": "^1.1.0"
 			}
 		},
-		"node_modules/strip-dirs/node_modules/is-plain-obj": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-			"integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/strip-final-newline": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
@@ -6983,17 +7081,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/strip-outer": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-2.0.0.tgz",
-			"integrity": "sha512-A21Xsm1XzUkK0qK1ZrytDUvqsQWict2Cykhvi0fBQntGG5JSprESasEyV1EZ/4CiR5WB5KjzLTrP/bO37B0wPg==",
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -7067,6 +7154,22 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/synckit": {
+			"version": "0.8.6",
+			"resolved": "https://registry.npmjs.org/synckit/-/synckit-0.8.6.tgz",
+			"integrity": "sha512-laHF2savN6sMeHCjLRkheIU4wo3Zg9Ln5YOjOo7sZ5dVQW8yF5pPE5SIw1dsPhq3TRp1jisKRCdPhfs/1WMqDA==",
+			"dev": true,
+			"dependencies": {
+				"@pkgr/utils": "^2.4.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": "^14.18.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/unts"
+			}
+		},
 		"node_modules/tapable": {
 			"version": "0.1.10",
 			"resolved": "https://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz",
@@ -7087,18 +7190,18 @@
 			}
 		},
 		"node_modules/temp-dir": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
-			"integrity": "sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-3.0.0.tgz",
+			"integrity": "sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==",
 			"dev": true,
 			"engines": {
-				"node": ">=8"
+				"node": ">=14.16"
 			}
 		},
 		"node_modules/terser": {
-			"version": "5.19.2",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.19.2.tgz",
-			"integrity": "sha512-qC5+dmecKJA4cpYxRa5aVkKehYsQKc+AHeKl0Oe62aYjBL8ZA33tTljktDHJSaxxMnbI5ZYw+o/S2DxxLu8OfA==",
+			"version": "5.26.0",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.26.0.tgz",
+			"integrity": "sha512-dytTGoE2oHgbNV9nTzgBEPaqAWvcJNl66VZ0BkJqlvp71IjO8CxdBx/ykCNb47cLnCmCvRZ6ZR0tLkqvZCdVBQ==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
@@ -7183,6 +7286,18 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/titleize": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/titleize/-/titleize-3.0.0.tgz",
+			"integrity": "sha512-KxVu8EYHDPBdUYdKZdKtU2aj2XfEx9AfjXxE/Aj0vT06w2icA09Vus1rh6eSu1y01akYg6BjIK/hxyLJINoMLQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/to-absolute-glob": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-3.0.0.tgz",
@@ -7224,27 +7339,16 @@
 				"url": "https://github.com/sponsors/Borewit"
 			}
 		},
-		"node_modules/trim-newlines": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-4.1.1.tgz",
-			"integrity": "sha512-jRKj0n0jXWo6kh62nA5TEh3+4igKDXLvzBJcPpiizP7oOolUrYIxmVBG9TOtHYFHoddUk6YvAkGeGoSVTXfQXQ==",
+		"node_modules/ts-api-utils": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.3.tgz",
+			"integrity": "sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==",
 			"dev": true,
 			"engines": {
-				"node": ">=12"
+				"node": ">=16.13.0"
 			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/trim-repeated": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-2.0.0.tgz",
-			"integrity": "sha512-QUHBFTJGdOwmp0tbOG505xAgOp/YliZP/6UgafFXYZ26WT1bvQmSMJUvkeVSASuJJHbqsFbynTvkd5W8RBTipg==",
-			"dependencies": {
-				"escape-string-regexp": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=12"
+			"peerDependencies": {
+				"typescript": ">=4.2.0"
 			}
 		},
 		"node_modules/tsconfig-paths": {
@@ -7258,6 +7362,12 @@
 				"minimist": "^1.2.6",
 				"strip-bom": "^3.0.0"
 			}
+		},
+		"node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+			"dev": true
 		},
 		"node_modules/type-check": {
 			"version": "0.4.0",
@@ -7349,9 +7459,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.1.6",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-			"integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+			"version": "5.3.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+			"integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
 			"dev": true,
 			"bin": {
 				"tsc": "bin/tsc",
@@ -7394,10 +7504,26 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/undici-types": {
+			"version": "5.26.5",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+			"dev": true,
+			"peer": true
+		},
+		"node_modules/untildify": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
+			"integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/update-browserslist-db": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz",
-			"integrity": "sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==",
+			"version": "1.0.13",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
+			"integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
 			"dev": true,
 			"funding": [
 				{
@@ -7435,9 +7561,9 @@
 			}
 		},
 		"node_modules/url-or-path": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/url-or-path/-/url-or-path-2.1.0.tgz",
-			"integrity": "sha512-dsBD6GbytSMj9YDb3jVzSRENwFh50oUORnWBeSHfo0Lnwv2KMm/J4npyGy1P9rivUPsUGLjTA53XqAFqpe0nww==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/url-or-path/-/url-or-path-2.3.0.tgz",
+			"integrity": "sha512-5g9xpEJKjbAY8ikLU3XFpEg3hRLGt6SbCQmDElb1AL7JTW6vMi5Na5e3dMvONHisIu9VHgMAADLHJ8EznYR2ow==",
 			"dev": true,
 			"funding": {
 				"url": "https://github.com/fisker/url-or-path?sponsor=1"
@@ -7449,14 +7575,14 @@
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
 		},
 		"node_modules/v8-to-istanbul": {
-			"version": "9.1.0",
-			"resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.1.0.tgz",
-			"integrity": "sha512-6z3GW9x8G1gd+JIIgQQQxXuiJtCXeAjp6RaPEPLv62mH3iPHPxV6W3robxtCzNErRo6ZwTmzWhsbNvjyEBKzKA==",
+			"version": "9.2.0",
+			"resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.2.0.tgz",
+			"integrity": "sha512-/EH/sDgxU2eGxajKdwLCDmQ4FWq+kpi3uCmBGpw1xJtnAxEjlD8j8PEiGWpCIMIs3ciNAgH0d3TTJiUkYzyZjA==",
 			"dev": true,
 			"dependencies": {
 				"@jridgewell/trace-mapping": "^0.3.12",
 				"@types/istanbul-lib-coverage": "^2.0.1",
-				"convert-source-map": "^1.6.0"
+				"convert-source-map": "^2.0.0"
 			},
 			"engines": {
 				"node": ">=10.12.0"
@@ -7487,9 +7613,9 @@
 			}
 		},
 		"node_modules/webpack": {
-			"version": "5.88.2",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.88.2.tgz",
-			"integrity": "sha512-JmcgNZ1iKj+aiR0OvTYtWQqJwq37Pf683dY9bVORwVbUrDhLhdn/PlO2sHsFHPkj7sHNQF3JwaAkp49V+Sq1tQ==",
+			"version": "5.89.0",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
+			"integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
@@ -7633,13 +7759,13 @@
 			}
 		},
 		"node_modules/which-typed-array": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.11.tgz",
-			"integrity": "sha512-qe9UWWpkeG5yzZ0tNYxDmd7vo58HDBc39mZ0xWWpolAGADdFOzkfamWLDxkOWcvHQKVmdTyQdLD4NOfjLWTKew==",
+			"version": "1.1.13",
+			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.13.tgz",
+			"integrity": "sha512-P5Nra0qjSncduVPEAr7xhoF5guty49ArDTwzJ/yNuPIbZppyRxFQsRCWrocxIY+CnMVG+qfbU2FmDKyvSGClow==",
 			"dev": true,
 			"dependencies": {
 				"available-typed-arrays": "^1.0.5",
-				"call-bind": "^1.0.2",
+				"call-bind": "^1.0.4",
 				"for-each": "^0.3.3",
 				"gopd": "^1.0.1",
 				"has-tostringtag": "^1.0.0"
@@ -7758,528 +7884,81 @@
 			"dev": true
 		},
 		"node_modules/write-file-atomic": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
-			"integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
+			"integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
 			"dev": true,
 			"dependencies": {
 				"imurmurhash": "^0.1.4",
-				"signal-exit": "^3.0.7"
+				"signal-exit": "^4.0.1"
 			},
 			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/write-file-atomic/node_modules/signal-exit": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"dev": true,
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/xo": {
-			"version": "0.54.2",
-			"resolved": "https://registry.npmjs.org/xo/-/xo-0.54.2.tgz",
-			"integrity": "sha512-1S3r+ecCg8OVPtu711as+cgwxOg+WQNRgSzqZ+OHzYlsa8CpW3ych0Ve9k8Q2QG6gqO3HSpaS5AXi9D0yPUffg==",
-			"bundleDependencies": [
-				"@typescript-eslint/eslint-plugin",
-				"@typescript-eslint/parser",
-				"eslint-config-xo-typescript"
-			],
+			"version": "0.56.0",
+			"resolved": "https://registry.npmjs.org/xo/-/xo-0.56.0.tgz",
+			"integrity": "sha512-ohzSqgQ8POgZ3KNaEK/gxDovb6h3cglxv8+xi9Dn7gmRe8g4qotpOZpMs5ACJhvkJDmJOhiKbk6Uq6Mx1Di9DA==",
 			"dev": true,
 			"dependencies": {
-				"@eslint/eslintrc": "^1.3.3",
-				"@typescript-eslint/eslint-plugin": "^5.59.1",
-				"@typescript-eslint/parser": "^5.59.1",
+				"@eslint/eslintrc": "^2.1.0",
+				"@typescript-eslint/eslint-plugin": "^6.0.0",
+				"@typescript-eslint/parser": "^6.0.0",
 				"arrify": "^3.0.0",
-				"cosmiconfig": "^8.1.3",
+				"cosmiconfig": "^8.2.0",
 				"define-lazy-prop": "^3.0.0",
-				"eslint": "^8.37.0",
+				"eslint": "^8.45.0",
 				"eslint-config-prettier": "^8.8.0",
 				"eslint-config-xo": "^0.43.1",
-				"eslint-config-xo-typescript": "^0.57.0",
+				"eslint-config-xo-typescript": "^1.0.0",
 				"eslint-formatter-pretty": "^5.0.0",
 				"eslint-import-resolver-webpack": "^0.13.2",
 				"eslint-plugin-ava": "^14.0.0",
 				"eslint-plugin-eslint-comments": "^3.2.0",
-				"eslint-plugin-import": "^2.27.5",
-				"eslint-plugin-n": "^15.7.0",
+				"eslint-plugin-import": "~2.27.5",
+				"eslint-plugin-n": "^16.0.1",
 				"eslint-plugin-no-use-extend-native": "^0.5.0",
-				"eslint-plugin-prettier": "^4.2.1",
-				"eslint-plugin-unicorn": "^46.0.0",
+				"eslint-plugin-prettier": "^5.0.0",
+				"eslint-plugin-unicorn": "^48.0.0",
 				"esm-utils": "^4.1.2",
 				"find-cache-dir": "^4.0.0",
 				"find-up": "^6.3.0",
 				"get-stdin": "^9.0.0",
-				"get-tsconfig": "^4.5.0",
-				"globby": "^13.1.2",
+				"get-tsconfig": "^4.6.2",
+				"globby": "^13.2.2",
 				"imurmurhash": "^0.1.4",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
 				"lodash-es": "^4.17.21",
-				"meow": "^11.0.0",
+				"meow": "^12.0.1",
 				"micromatch": "^4.0.5",
 				"open-editor": "^4.0.0",
-				"prettier": "^2.8.7",
-				"semver": "^7.3.8",
-				"slash": "^5.0.0",
+				"prettier": "^3.0.0",
+				"semver": "^7.5.4",
+				"slash": "^5.1.0",
 				"to-absolute-glob": "^3.0.0",
-				"typescript": "^5.0.3"
+				"typescript": "^5.1.6"
 			},
 			"bin": {
 				"xo": "cli.js"
 			},
 			"engines": {
-				"node": ">=14.16"
+				"node": ">=16"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/xo/node_modules/@eslint-community/eslint-utils": {
-			"version": "4.4.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"eslint-visitor-keys": "^3.3.0"
-			},
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"peerDependencies": {
-				"eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
-			}
-		},
-		"node_modules/xo/node_modules/@eslint-community/regexpp": {
-			"version": "4.5.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^12.0.0 || ^14.0.0 || >=16.0.0"
-			}
-		},
-		"node_modules/xo/node_modules/@nodelib/fs.scandir": {
-			"version": "2.1.5",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"@nodelib/fs.stat": "2.0.5",
-				"run-parallel": "^1.1.9"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/xo/node_modules/@nodelib/fs.stat": {
-			"version": "2.0.5",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/xo/node_modules/@nodelib/fs.walk": {
-			"version": "1.2.8",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"@nodelib/fs.scandir": "2.1.5",
-				"fastq": "^1.6.0"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/xo/node_modules/@types/json-schema": {
-			"version": "7.0.11",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT"
-		},
-		"node_modules/xo/node_modules/@types/semver": {
-			"version": "7.3.13",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT"
-		},
-		"node_modules/xo/node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "5.59.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"@eslint-community/regexpp": "^4.4.0",
-				"@typescript-eslint/scope-manager": "5.59.1",
-				"@typescript-eslint/type-utils": "5.59.1",
-				"@typescript-eslint/utils": "5.59.1",
-				"debug": "^4.3.4",
-				"grapheme-splitter": "^1.0.4",
-				"ignore": "^5.2.0",
-				"natural-compare-lite": "^1.4.0",
-				"semver": "^7.3.7",
-				"tsutils": "^3.21.0"
-			},
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependencies": {
-				"@typescript-eslint/parser": "^5.0.0",
-				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/xo/node_modules/@typescript-eslint/parser": {
-			"version": "5.59.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"@typescript-eslint/scope-manager": "5.59.1",
-				"@typescript-eslint/types": "5.59.1",
-				"@typescript-eslint/typescript-estree": "5.59.1",
-				"debug": "^4.3.4"
-			},
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependencies": {
-				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/xo/node_modules/@typescript-eslint/scope-manager": {
-			"version": "5.59.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"@typescript-eslint/types": "5.59.1",
-				"@typescript-eslint/visitor-keys": "5.59.1"
-			},
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/xo/node_modules/@typescript-eslint/type-utils": {
-			"version": "5.59.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"@typescript-eslint/typescript-estree": "5.59.1",
-				"@typescript-eslint/utils": "5.59.1",
-				"debug": "^4.3.4",
-				"tsutils": "^3.21.0"
-			},
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependencies": {
-				"eslint": "*"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/xo/node_modules/@typescript-eslint/types": {
-			"version": "5.59.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/xo/node_modules/@typescript-eslint/typescript-estree": {
-			"version": "5.59.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"@typescript-eslint/types": "5.59.1",
-				"@typescript-eslint/visitor-keys": "5.59.1",
-				"debug": "^4.3.4",
-				"globby": "^11.1.0",
-				"is-glob": "^4.0.3",
-				"semver": "^7.3.7",
-				"tsutils": "^3.21.0"
-			},
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/xo/node_modules/@typescript-eslint/typescript-estree/node_modules/globby": {
-			"version": "11.1.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"array-union": "^2.1.0",
-				"dir-glob": "^3.0.1",
-				"fast-glob": "^3.2.9",
-				"ignore": "^5.2.0",
-				"merge2": "^1.4.1",
-				"slash": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/xo/node_modules/@typescript-eslint/typescript-estree/node_modules/slash": {
-			"version": "3.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/xo/node_modules/@typescript-eslint/utils": {
-			"version": "5.59.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"@eslint-community/eslint-utils": "^4.2.0",
-				"@types/json-schema": "^7.0.9",
-				"@types/semver": "^7.3.12",
-				"@typescript-eslint/scope-manager": "5.59.1",
-				"@typescript-eslint/types": "5.59.1",
-				"@typescript-eslint/typescript-estree": "5.59.1",
-				"eslint-scope": "^5.1.1",
-				"semver": "^7.3.7"
-			},
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependencies": {
-				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
-			}
-		},
-		"node_modules/xo/node_modules/@typescript-eslint/visitor-keys": {
-			"version": "5.59.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"@typescript-eslint/types": "5.59.1",
-				"eslint-visitor-keys": "^3.3.0"
-			},
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/xo/node_modules/array-union": {
-			"version": "2.1.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/xo/node_modules/braces": {
-			"version": "3.0.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"fill-range": "^7.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/xo/node_modules/debug": {
-			"version": "4.3.4",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"ms": "2.1.2"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/xo/node_modules/debug/node_modules/ms": {
-			"version": "2.1.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT"
-		},
-		"node_modules/xo/node_modules/dir-glob": {
-			"version": "3.0.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"path-type": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/xo/node_modules/eslint-config-xo-typescript": {
-			"version": "0.57.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			},
-			"peerDependencies": {
-				"@typescript-eslint/eslint-plugin": ">=5.57.0",
-				"@typescript-eslint/parser": ">=5.57.0",
-				"eslint": ">=8.0.0",
-				"typescript": ">=4.4"
-			}
-		},
-		"node_modules/xo/node_modules/eslint-scope": {
-			"version": "5.1.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"esrecurse": "^4.3.0",
-				"estraverse": "^4.1.1"
-			},
-			"engines": {
-				"node": ">=8.0.0"
-			}
-		},
-		"node_modules/xo/node_modules/eslint-scope/node_modules/estraverse": {
-			"version": "4.3.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "BSD-2-Clause",
-			"engines": {
-				"node": ">=4.0"
-			}
-		},
-		"node_modules/xo/node_modules/eslint-visitor-keys": {
-			"version": "3.4.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "Apache-2.0",
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/eslint"
-			}
-		},
-		"node_modules/xo/node_modules/esrecurse": {
-			"version": "4.3.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"estraverse": "^5.2.0"
-			},
-			"engines": {
-				"node": ">=4.0"
-			}
-		},
-		"node_modules/xo/node_modules/estraverse": {
-			"version": "5.3.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "BSD-2-Clause",
-			"engines": {
-				"node": ">=4.0"
-			}
-		},
-		"node_modules/xo/node_modules/fast-glob": {
-			"version": "3.2.12",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"@nodelib/fs.stat": "^2.0.2",
-				"@nodelib/fs.walk": "^1.2.3",
-				"glob-parent": "^5.1.2",
-				"merge2": "^1.3.0",
-				"micromatch": "^4.0.4"
-			},
-			"engines": {
-				"node": ">=8.6.0"
-			}
-		},
-		"node_modules/xo/node_modules/fastq": {
-			"version": "1.15.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"reusify": "^1.0.4"
-			}
-		},
-		"node_modules/xo/node_modules/fill-range": {
-			"version": "7.0.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"to-regex-range": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/xo/node_modules/find-up": {
@@ -8298,63 +7977,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/xo/node_modules/glob-parent": {
-			"version": "5.1.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"is-glob": "^4.0.1"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
-		"node_modules/xo/node_modules/grapheme-splitter": {
-			"version": "1.0.4",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT"
-		},
-		"node_modules/xo/node_modules/ignore": {
-			"version": "5.2.4",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 4"
-			}
-		},
-		"node_modules/xo/node_modules/is-extglob": {
-			"version": "2.1.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/xo/node_modules/is-glob": {
-			"version": "4.0.3",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"is-extglob": "^2.1.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/xo/node_modules/is-number": {
-			"version": "7.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.12.0"
-			}
-		},
 		"node_modules/xo/node_modules/locate-path": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
@@ -8369,34 +7991,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
-		},
-		"node_modules/xo/node_modules/merge2": {
-			"version": "1.4.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/xo/node_modules/micromatch": {
-			"version": "4.0.5",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"braces": "^3.0.2",
-				"picomatch": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=8.6"
-			}
-		},
-		"node_modules/xo/node_modules/natural-compare-lite": {
-			"version": "1.4.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT"
 		},
 		"node_modules/xo/node_modules/p-limit": {
 			"version": "4.0.0",
@@ -8428,113 +8022,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/xo/node_modules/path-type": {
-			"version": "4.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/xo/node_modules/picomatch": {
-			"version": "2.3.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
-		"node_modules/xo/node_modules/queue-microtask": {
-			"version": "1.2.3",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"inBundle": true,
-			"license": "MIT"
-		},
-		"node_modules/xo/node_modules/reusify": {
-			"version": "1.0.4",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"iojs": ">=1.0.0",
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/xo/node_modules/run-parallel": {
-			"version": "1.2.0",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"queue-microtask": "^1.2.2"
-			}
-		},
-		"node_modules/xo/node_modules/semver": {
-			"version": "7.5.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/xo/node_modules/semver/node_modules/lru-cache": {
-			"version": "6.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/xo/node_modules/semver/node_modules/yallist": {
-			"version": "4.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC"
-		},
 		"node_modules/xo/node_modules/slash": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
@@ -8545,39 +8032,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/xo/node_modules/to-regex-range": {
-			"version": "5.0.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"is-number": "^7.0.0"
-			},
-			"engines": {
-				"node": ">=8.0"
-			}
-		},
-		"node_modules/xo/node_modules/tslib": {
-			"version": "1.14.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "0BSD"
-		},
-		"node_modules/xo/node_modules/tsutils": {
-			"version": "3.21.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"tslib": "^1.8.1"
-			},
-			"engines": {
-				"node": ">= 6"
-			},
-			"peerDependencies": {
-				"typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
 			}
 		},
 		"node_modules/xo/node_modules/yocto-queue": {
@@ -8713,28 +8167,72 @@
 			"dev": true
 		},
 		"@babel/code-frame": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.5.tgz",
-			"integrity": "sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==",
+			"version": "7.23.5",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
+			"integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
 			"dev": true,
 			"requires": {
-				"@babel/highlight": "^7.22.5"
+				"@babel/highlight": "^7.23.4",
+				"chalk": "^2.4.2"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"escape-string-regexp": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+					"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
 			}
 		},
 		"@babel/helper-validator-identifier": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz",
-			"integrity": "sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==",
+			"version": "7.22.20",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+			"integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
 			"dev": true
 		},
 		"@babel/highlight": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.5.tgz",
-			"integrity": "sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==",
+			"version": "7.23.4",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
+			"integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-validator-identifier": "^7.22.5",
-				"chalk": "^2.0.0",
+				"@babel/helper-validator-identifier": "^7.22.20",
+				"chalk": "^2.4.2",
 				"js-tokens": "^4.0.0"
 			},
 			"dependencies": {
@@ -8797,20 +8295,20 @@
 			}
 		},
 		"@eslint-community/regexpp": {
-			"version": "4.6.2",
-			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.6.2.tgz",
-			"integrity": "sha512-pPTNuaAG3QMH+buKyBIGJs3g/S5y0caxw0ygM3YyE6yJFySwiGGSzA+mM3KJ8QQvzeLh3blwgSonkFjgQdxzMw==",
+			"version": "4.10.0",
+			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.0.tgz",
+			"integrity": "sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==",
 			"dev": true
 		},
 		"@eslint/eslintrc": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.4.1.tgz",
-			"integrity": "sha512-XXrH9Uarn0stsyldqDYq8r++mROmWRI1xKMXa640Bb//SY1+ECYX6VzT6Lcx5frD0V30XieqJ0oX9I2Xj5aoMA==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+			"integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
 			"dev": true,
 			"requires": {
 				"ajv": "^6.12.4",
 				"debug": "^4.3.2",
-				"espree": "^9.4.0",
+				"espree": "^9.6.0",
 				"globals": "^13.19.0",
 				"ignore": "^5.2.0",
 				"import-fresh": "^3.2.1",
@@ -8837,18 +8335,18 @@
 			}
 		},
 		"@eslint/js": {
-			"version": "8.46.0",
-			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.46.0.tgz",
-			"integrity": "sha512-a8TLtmPi8xzPkCbp/OGFUo5yhRkHM2Ko9kOWP4znJr0WAhWyThaw3PnwX4vOTWOAMsV2uRt32PPDcEz63esSaA==",
+			"version": "8.55.0",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.55.0.tgz",
+			"integrity": "sha512-qQfo2mxH5yVom1kacMtZZJFVdW+E70mqHMJvVg6WTLo+VBuQJ4TojZlfWBjK0ve5BdEeNAVxOsl/nvNMpJOaJA==",
 			"dev": true
 		},
 		"@humanwhocodes/config-array": {
-			"version": "0.11.10",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
-			"integrity": "sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==",
+			"version": "0.11.13",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.13.tgz",
+			"integrity": "sha512-JSBDMiDKSzQVngfRjOdFXgFfklaXI4K9nLF49Auh21lmBWRLIK3+xTErTWD4KU54pb6coM6ESE7Awz/FNU3zgQ==",
 			"dev": true,
 			"requires": {
-				"@humanwhocodes/object-schema": "^1.2.1",
+				"@humanwhocodes/object-schema": "^2.0.1",
 				"debug": "^4.1.1",
 				"minimatch": "^3.0.5"
 			}
@@ -8860,9 +8358,9 @@
 			"dev": true
 		},
 		"@humanwhocodes/object-schema": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
-			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.1.tgz",
+			"integrity": "sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==",
 			"dev": true
 		},
 		"@istanbuljs/schema": {
@@ -8884,9 +8382,9 @@
 			}
 		},
 		"@jridgewell/resolve-uri": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
-			"integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
+			"integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
 			"dev": true
 		},
 		"@jridgewell/set-array": {
@@ -8908,19 +8406,19 @@
 			}
 		},
 		"@jridgewell/sourcemap-codec": {
-			"version": "1.4.14",
-			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-			"integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+			"version": "1.4.15",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+			"integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
 			"dev": true
 		},
 		"@jridgewell/trace-mapping": {
-			"version": "0.3.18",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.18.tgz",
-			"integrity": "sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==",
+			"version": "0.3.20",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz",
+			"integrity": "sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==",
 			"dev": true,
 			"requires": {
-				"@jridgewell/resolve-uri": "3.1.0",
-				"@jridgewell/sourcemap-codec": "1.4.14"
+				"@jridgewell/resolve-uri": "^3.1.0",
+				"@jridgewell/sourcemap-codec": "^1.4.14"
 			}
 		},
 		"@nodelib/fs.scandir": {
@@ -8949,6 +8447,34 @@
 				"fastq": "^1.6.0"
 			}
 		},
+		"@pkgr/utils": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/@pkgr/utils/-/utils-2.4.2.tgz",
+			"integrity": "sha512-POgTXhjrTfbTV63DiFXav4lBHiICLKKwDeaKn9Nphwj7WH6m0hMMCaJkMyRWjgtPFyRKRVoMXXjczsTQRDEhYw==",
+			"dev": true,
+			"requires": {
+				"cross-spawn": "^7.0.3",
+				"fast-glob": "^3.3.0",
+				"is-glob": "^4.0.3",
+				"open": "^9.1.0",
+				"picocolors": "^1.0.0",
+				"tslib": "^2.6.0"
+			},
+			"dependencies": {
+				"open": {
+					"version": "9.1.0",
+					"resolved": "https://registry.npmjs.org/open/-/open-9.1.0.tgz",
+					"integrity": "sha512-OS+QTnw1/4vrf+9hh1jc1jnYjzSG4ttTBB8UxOwAnInG3Uo4ssetzC1ihqaIHjLJnA5GGlRl6QlZXOTQhRBUvg==",
+					"dev": true,
+					"requires": {
+						"default-browser": "^4.0.0",
+						"define-lazy-prop": "^3.0.0",
+						"is-inside-container": "^1.0.0",
+						"is-wsl": "^2.2.0"
+					}
+				}
+			}
+		},
 		"@sindresorhus/is": {
 			"version": "5.6.0",
 			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-5.6.0.tgz",
@@ -8968,9 +8494,9 @@
 			"integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
 		},
 		"@types/eslint": {
-			"version": "8.44.1",
-			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.44.1.tgz",
-			"integrity": "sha512-XpNDc4Z5Tb4x+SW1MriMVeIsMoONHCkWFMkR/aPJbzEsxqHy+4Glu/BqTdPrApfDeMaXbtNh6bseNgl5KaWrSg==",
+			"version": "8.44.8",
+			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.44.8.tgz",
+			"integrity": "sha512-4K8GavROwhrYl2QXDXm0Rv9epkA8GBFu0EI+XrrnnuCl7u8CWBRusX7fXJfanhZTDWSAL24gDI/UqXyUM0Injw==",
 			"dev": true,
 			"requires": {
 				"@types/estree": "*",
@@ -8978,9 +8504,9 @@
 			}
 		},
 		"@types/eslint-scope": {
-			"version": "3.7.4",
-			"resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.4.tgz",
-			"integrity": "sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==",
+			"version": "3.7.7",
+			"resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
+			"integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
 			"dev": true,
 			"peer": true,
 			"requires": {
@@ -8989,26 +8515,26 @@
 			}
 		},
 		"@types/estree": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.1.tgz",
-			"integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+			"integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
 			"dev": true
 		},
 		"@types/http-cache-semantics": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
-			"integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ=="
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
+			"integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA=="
 		},
 		"@types/istanbul-lib-coverage": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
-			"integrity": "sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g==",
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+			"integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
 			"dev": true
 		},
 		"@types/json-schema": {
-			"version": "7.0.12",
-			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
-			"integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
+			"version": "7.0.15",
+			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+			"integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
 			"dev": true
 		},
 		"@types/json5": {
@@ -9017,23 +8543,154 @@
 			"integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
 			"dev": true
 		},
-		"@types/minimist": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
-			"integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
-			"dev": true
-		},
 		"@types/node": {
-			"version": "20.4.5",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.5.tgz",
-			"integrity": "sha512-rt40Nk13II9JwQBdeYqmbn2Q6IVTA5uPhvSO+JVqdXw/6/4glI6oR9ezty/A9Hg5u7JH4OmYmuQ+XvjKm0Datg==",
+			"version": "20.10.4",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.4.tgz",
+			"integrity": "sha512-D08YG6rr8X90YB56tSIuBaddy/UXAA9RKJoFvrsnogAum/0pmjkgi4+2nx96A330FmioegBWmEYQ+syqCFaveg==",
 			"dev": true,
-			"peer": true
+			"peer": true,
+			"requires": {
+				"undici-types": "~5.26.4"
+			}
 		},
 		"@types/normalize-package-data": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
-			"integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
+			"version": "2.4.4",
+			"resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
+			"integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
+			"dev": true
+		},
+		"@types/semver": {
+			"version": "7.5.6",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.6.tgz",
+			"integrity": "sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==",
+			"dev": true
+		},
+		"@typescript-eslint/eslint-plugin": {
+			"version": "6.13.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.13.2.tgz",
+			"integrity": "sha512-3+9OGAWHhk4O1LlcwLBONbdXsAhLjyCFogJY/cWy2lxdVJ2JrcTF2pTGMaLl2AE7U1l31n8Py4a8bx5DLf/0dQ==",
+			"dev": true,
+			"requires": {
+				"@eslint-community/regexpp": "^4.5.1",
+				"@typescript-eslint/scope-manager": "6.13.2",
+				"@typescript-eslint/type-utils": "6.13.2",
+				"@typescript-eslint/utils": "6.13.2",
+				"@typescript-eslint/visitor-keys": "6.13.2",
+				"debug": "^4.3.4",
+				"graphemer": "^1.4.0",
+				"ignore": "^5.2.4",
+				"natural-compare": "^1.4.0",
+				"semver": "^7.5.4",
+				"ts-api-utils": "^1.0.1"
+			}
+		},
+		"@typescript-eslint/parser": {
+			"version": "6.13.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.13.2.tgz",
+			"integrity": "sha512-MUkcC+7Wt/QOGeVlM8aGGJZy1XV5YKjTpq9jK6r6/iLsGXhBVaGP5N0UYvFsu9BFlSpwY9kMretzdBH01rkRXg==",
+			"dev": true,
+			"requires": {
+				"@typescript-eslint/scope-manager": "6.13.2",
+				"@typescript-eslint/types": "6.13.2",
+				"@typescript-eslint/typescript-estree": "6.13.2",
+				"@typescript-eslint/visitor-keys": "6.13.2",
+				"debug": "^4.3.4"
+			}
+		},
+		"@typescript-eslint/scope-manager": {
+			"version": "6.13.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.13.2.tgz",
+			"integrity": "sha512-CXQA0xo7z6x13FeDYCgBkjWzNqzBn8RXaE3QVQVIUm74fWJLkJkaHmHdKStrxQllGh6Q4eUGyNpMe0b1hMkXFA==",
+			"dev": true,
+			"requires": {
+				"@typescript-eslint/types": "6.13.2",
+				"@typescript-eslint/visitor-keys": "6.13.2"
+			}
+		},
+		"@typescript-eslint/type-utils": {
+			"version": "6.13.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.13.2.tgz",
+			"integrity": "sha512-Qr6ssS1GFongzH2qfnWKkAQmMUyZSyOr0W54nZNU1MDfo+U4Mv3XveeLZzadc/yq8iYhQZHYT+eoXJqnACM1tw==",
+			"dev": true,
+			"requires": {
+				"@typescript-eslint/typescript-estree": "6.13.2",
+				"@typescript-eslint/utils": "6.13.2",
+				"debug": "^4.3.4",
+				"ts-api-utils": "^1.0.1"
+			}
+		},
+		"@typescript-eslint/types": {
+			"version": "6.13.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.13.2.tgz",
+			"integrity": "sha512-7sxbQ+EMRubQc3wTfTsycgYpSujyVbI1xw+3UMRUcrhSy+pN09y/lWzeKDbvhoqcRbHdc+APLs/PWYi/cisLPg==",
+			"dev": true
+		},
+		"@typescript-eslint/typescript-estree": {
+			"version": "6.13.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.13.2.tgz",
+			"integrity": "sha512-SuD8YLQv6WHnOEtKv8D6HZUzOub855cfPnPMKvdM/Bh1plv1f7Q/0iFUDLKKlxHcEstQnaUU4QZskgQq74t+3w==",
+			"dev": true,
+			"requires": {
+				"@typescript-eslint/types": "6.13.2",
+				"@typescript-eslint/visitor-keys": "6.13.2",
+				"debug": "^4.3.4",
+				"globby": "^11.1.0",
+				"is-glob": "^4.0.3",
+				"semver": "^7.5.4",
+				"ts-api-utils": "^1.0.1"
+			},
+			"dependencies": {
+				"globby": {
+					"version": "11.1.0",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+					"integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+					"dev": true,
+					"requires": {
+						"array-union": "^2.1.0",
+						"dir-glob": "^3.0.1",
+						"fast-glob": "^3.2.9",
+						"ignore": "^5.2.0",
+						"merge2": "^1.4.1",
+						"slash": "^3.0.0"
+					}
+				},
+				"slash": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+					"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+					"dev": true
+				}
+			}
+		},
+		"@typescript-eslint/utils": {
+			"version": "6.13.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.13.2.tgz",
+			"integrity": "sha512-b9Ptq4eAZUym4idijCRzl61oPCwwREcfDI8xGk751Vhzig5fFZR9CyzDz4Sp/nxSLBYxUPyh4QdIDqWykFhNmQ==",
+			"dev": true,
+			"requires": {
+				"@eslint-community/eslint-utils": "^4.4.0",
+				"@types/json-schema": "^7.0.12",
+				"@types/semver": "^7.5.0",
+				"@typescript-eslint/scope-manager": "6.13.2",
+				"@typescript-eslint/types": "6.13.2",
+				"@typescript-eslint/typescript-estree": "6.13.2",
+				"semver": "^7.5.4"
+			}
+		},
+		"@typescript-eslint/visitor-keys": {
+			"version": "6.13.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.13.2.tgz",
+			"integrity": "sha512-OGznFs0eAQXJsp+xSd6k/O1UbFi/K/L7WjqeRoFE7vadjAF9y0uppXhYNQNEqygjou782maGClOoZwPqF0Drlw==",
+			"dev": true,
+			"requires": {
+				"@typescript-eslint/types": "6.13.2",
+				"eslint-visitor-keys": "^3.4.1"
+			}
+		},
+		"@ungap/structured-clone": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
+			"integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
 			"dev": true
 		},
 		"@webassemblyjs/ast": {
@@ -9276,9 +8933,9 @@
 			"peer": true
 		},
 		"acorn": {
-			"version": "8.10.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
-			"integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+			"version": "8.11.2",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
+			"integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
 			"dev": true
 		},
 		"acorn-import-assertions": {
@@ -9297,9 +8954,9 @@
 			"requires": {}
 		},
 		"acorn-walk": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-			"integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+			"version": "8.3.1",
+			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.1.tgz",
+			"integrity": "sha512-TgUZgYvqZprrl7YldZNoa9OciCAyZR+Ejm9eXzKCmjsF5IKp/wgQ7Z/ZpjpGTIUPwrHQIcYeI8qDh4PsEwxMbw==",
 			"dev": true
 		},
 		"aggregate-error": {
@@ -9390,12 +9047,6 @@
 				"is-array-buffer": "^3.0.1"
 			}
 		},
-		"array-find": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/array-find/-/array-find-1.0.0.tgz",
-			"integrity": "sha512-kO/vVCacW9mnpn3WPWbTVlEnOabK2L7LWi2HViURtCM46y1zb6I8UMjx4LgbiqadTgHnLInUronwn3ampNTJtQ==",
-			"dev": true
-		},
 		"array-find-index": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
@@ -9403,15 +9054,15 @@
 			"dev": true
 		},
 		"array-includes": {
-			"version": "3.1.6",
-			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.6.tgz",
-			"integrity": "sha512-sgTbLvL6cNnw24FnbaDyjmvddQ2ML8arZsgaJhoABMoplz/4QRhtrYS+alr1BUM1Bwp6dhx8vVCBSLG+StwOFw==",
+			"version": "3.1.7",
+			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.7.tgz",
+			"integrity": "sha512-dlcsNBIiWhPkHdOEEKnehA+RNUWDc4UqFtnIXU4uuYDPtA4LDkr7qip2p0VvFAEXNDr0yWZ9PJyIRiGjRLQzwQ==",
 			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.4",
-				"es-abstract": "^1.20.4",
-				"get-intrinsic": "^1.1.3",
+				"define-properties": "^1.2.0",
+				"es-abstract": "^1.22.1",
+				"get-intrinsic": "^1.2.1",
 				"is-string": "^1.0.7"
 			}
 		},
@@ -9421,52 +9072,52 @@
 			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
 			"dev": true
 		},
-		"array.prototype.findlastindex": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.2.tgz",
-			"integrity": "sha512-tb5thFFlUcp7NdNF6/MpDk/1r/4awWG1FIz3YqDf+/zJSTezBb+/5WViH41obXULHVpDzoiCLpJ/ZO9YbJMsdw==",
+		"array.prototype.find": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.2.2.tgz",
+			"integrity": "sha512-DRumkfW97iZGOfn+lIXbkVrXL04sfYKX+EfOodo8XboR5sxPDVvOjZTF/rysusa9lmhmSOeD6Vp6RKQP+eP4Tg==",
 			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.4",
-				"es-abstract": "^1.20.4",
-				"es-shim-unscopables": "^1.0.0",
-				"get-intrinsic": "^1.1.3"
+				"define-properties": "^1.2.0",
+				"es-abstract": "^1.22.1",
+				"es-shim-unscopables": "^1.0.0"
 			}
 		},
 		"array.prototype.flat": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.1.tgz",
-			"integrity": "sha512-roTU0KWIOmJ4DRLmwKd19Otg0/mT3qPNt0Qb3GWW8iObuZXxrjB/pzn0R3hqpRSWg4HCwqx+0vwOnWnvlOyeIA==",
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.2.tgz",
+			"integrity": "sha512-djYB+Zx2vLewY8RWlNCUdHjDXs2XOgm602S9E7P/UpHgfeHL00cRiIF+IN/G/aUJ7kGPb6yO/ErDI5V2s8iycA==",
 			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.4",
-				"es-abstract": "^1.20.4",
+				"define-properties": "^1.2.0",
+				"es-abstract": "^1.22.1",
 				"es-shim-unscopables": "^1.0.0"
 			}
 		},
 		"array.prototype.flatmap": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.1.tgz",
-			"integrity": "sha512-8UGn9O1FDVvMNB0UlLv4voxRMze7+FpHyF5mSMRjWHUMlpoDViniy05870VlxhfgTnLbpuwTzvD76MTtWxB/mQ==",
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.2.tgz",
+			"integrity": "sha512-Ewyx0c9PmpcsByhSW4r+9zDU7sGjFc86qf/kKtuSCRdhfbk0SNLLkaT5qvcHnRGgc5NP/ly/y+qkXkqONX54CQ==",
 			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.4",
-				"es-abstract": "^1.20.4",
+				"define-properties": "^1.2.0",
+				"es-abstract": "^1.22.1",
 				"es-shim-unscopables": "^1.0.0"
 			}
 		},
 		"arraybuffer.prototype.slice": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.1.tgz",
-			"integrity": "sha512-09x0ZWFEjj4WD8PDbykUwo3t9arLn8NIzmmYEJFpYekOAQjpkGSyrQhNoRTcwwcFRu+ycWF78QZ63oWTqSjBcw==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.2.tgz",
+			"integrity": "sha512-yMBKppFur/fbHu9/6USUe03bZ4knMYiwFBcyiaXB8Go0qNehwX6inYPzK9U0NeQvGxKthcmHcaR8P5MStSRBAw==",
 			"dev": true,
 			"requires": {
 				"array-buffer-byte-length": "^1.0.0",
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.2.0",
+				"es-abstract": "^1.22.1",
 				"get-intrinsic": "^1.2.1",
 				"is-array-buffer": "^3.0.2",
 				"is-shared-array-buffer": "^1.0.2"
@@ -9485,22 +9136,22 @@
 			"dev": true
 		},
 		"ava": {
-			"version": "4.3.3",
-			"resolved": "https://registry.npmjs.org/ava/-/ava-4.3.3.tgz",
-			"integrity": "sha512-9Egq/d9R74ExrWohHeqUlexjDbgZJX5jA1Wq4KCTqc3wIfpGEK79zVy4rBtofJ9YKIxs4PzhJ8BgbW5PlAYe6w==",
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/ava/-/ava-5.3.1.tgz",
+			"integrity": "sha512-Scv9a4gMOXB6+ni4toLuhAm9KYWEjsgBglJl+kMGI5+IVDt120CCDZyB5HNU9DjmLI2t4I0GbnxGLmmRfGTJGg==",
 			"dev": true,
 			"requires": {
-				"acorn": "^8.7.1",
+				"acorn": "^8.8.2",
 				"acorn-walk": "^8.2.0",
-				"ansi-styles": "^6.1.0",
+				"ansi-styles": "^6.2.1",
 				"arrgv": "^1.0.2",
 				"arrify": "^3.0.0",
 				"callsites": "^4.0.0",
 				"cbor": "^8.1.0",
-				"chalk": "^5.0.1",
+				"chalk": "^5.2.0",
 				"chokidar": "^3.5.3",
 				"chunkd": "^2.0.1",
-				"ci-info": "^3.3.1",
+				"ci-info": "^3.8.0",
 				"ci-parallel-vars": "^1.0.1",
 				"clean-yaml-object": "^0.1.0",
 				"cli-truncate": "^3.1.0",
@@ -9509,10 +9160,9 @@
 				"concordance": "^5.0.4",
 				"currently-unhandled": "^0.4.1",
 				"debug": "^4.3.4",
-				"del": "^6.1.1",
-				"emittery": "^0.11.0",
-				"figures": "^4.0.1",
-				"globby": "^13.1.1",
+				"emittery": "^1.0.1",
+				"figures": "^5.0.0",
+				"globby": "^13.1.4",
 				"ignore-by-default": "^2.1.0",
 				"indent-string": "^5.0.0",
 				"is-error": "^2.2.2",
@@ -9522,19 +9172,35 @@
 				"mem": "^9.0.2",
 				"ms": "^2.1.3",
 				"p-event": "^5.0.1",
-				"p-map": "^5.4.0",
+				"p-map": "^5.5.0",
 				"picomatch": "^2.3.1",
 				"pkg-conf": "^4.0.0",
 				"plur": "^5.1.0",
-				"pretty-ms": "^7.0.1",
+				"pretty-ms": "^8.0.0",
 				"resolve-cwd": "^3.0.0",
-				"slash": "^3.0.0",
-				"stack-utils": "^2.0.5",
+				"stack-utils": "^2.0.6",
 				"strip-ansi": "^7.0.1",
 				"supertap": "^3.0.1",
-				"temp-dir": "^2.0.0",
-				"write-file-atomic": "^4.0.1",
-				"yargs": "^17.5.1"
+				"temp-dir": "^3.0.0",
+				"write-file-atomic": "^5.0.1",
+				"yargs": "^17.7.2"
+			},
+			"dependencies": {
+				"p-event": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/p-event/-/p-event-5.0.1.tgz",
+					"integrity": "sha512-dd589iCQ7m1L0bmC5NLlVYfy3TbBEsMUfWx9PyAgPeIcFZ/E2yaTZ4Rz4MiBmmJShviiftHVXOqfnfzJ6kyMrQ==",
+					"dev": true,
+					"requires": {
+						"p-timeout": "^5.0.2"
+					}
+				},
+				"p-timeout": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-5.1.0.tgz",
+					"integrity": "sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew==",
+					"dev": true
+				}
 			}
 		},
 		"available-typed-arrays": {
@@ -9559,6 +9225,12 @@
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
 			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
 		},
+		"big-integer": {
+			"version": "1.6.52",
+			"resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
+			"integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
+			"dev": true
+		},
 		"binary-extensions": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -9570,6 +9242,15 @@
 			"resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.19.0.tgz",
 			"integrity": "sha512-DRQrD6gJyy8FbiE4s+bDoXS9hiW3Vbx5uCdwvcCf3zLHL+Iv7LtGHLpr+GZV8rHG8tK766FGYBwRbu8pELTt+w==",
 			"dev": true
+		},
+		"bplist-parser": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.2.0.tgz",
+			"integrity": "sha512-z0M+byMThzQmD9NILRniCUXYsYpjwnlO8N5uCFaCqIOpqRsJCrQL9NK3JsD67CN5a08nF5oIL2bD6loTdHOuKw==",
+			"dev": true,
+			"requires": {
+				"big-integer": "^1.6.44"
+			}
 		},
 		"brace-expansion": {
 			"version": "1.1.11",
@@ -9591,16 +9272,16 @@
 			}
 		},
 		"browserslist": {
-			"version": "4.21.10",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.10.tgz",
-			"integrity": "sha512-bipEBdZfVH5/pwrvqc+Ub0kUPVfGUhlKxbvfD+z1BDnPEO/X98ruXGA1WP5ASpAFKan7Qr6j736IacbZQuAlKQ==",
+			"version": "4.22.2",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.2.tgz",
+			"integrity": "sha512-0UgcrvQmBDvZHFGdYUehrCNIazki7/lUP3kkoi/r3YB2amZbFM9J43ZRkJTXBUZK4gmx56+Sqk9+Vs9mwZx9+A==",
 			"dev": true,
 			"peer": true,
 			"requires": {
-				"caniuse-lite": "^1.0.30001517",
-				"electron-to-chromium": "^1.4.477",
-				"node-releases": "^2.0.13",
-				"update-browserslist-db": "^1.0.11"
+				"caniuse-lite": "^1.0.30001565",
+				"electron-to-chromium": "^1.4.601",
+				"node-releases": "^2.0.14",
+				"update-browserslist-db": "^1.0.13"
 			}
 		},
 		"buffer": {
@@ -9639,6 +9320,15 @@
 				"semver": "^7.0.0"
 			}
 		},
+		"bundle-name": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-3.0.0.tgz",
+			"integrity": "sha512-PKA4BeSvBpQKQ8iPOGCSiell+N8P+Tf1DlwqmYhpe2gAhKPHn8EYOxVT+ShuGmhg8lN8XiSlS80yiExKXrURlw==",
+			"dev": true,
+			"requires": {
+				"run-applescript": "^5.0.0"
+			}
+		},
 		"c8": {
 			"version": "8.0.1",
 			"resolved": "https://registry.npmjs.org/c8/-/c8-8.0.1.tgz",
@@ -9665,11 +9355,11 @@
 			"integrity": "sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w=="
 		},
 		"cacheable-request": {
-			"version": "10.2.13",
-			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-10.2.13.tgz",
-			"integrity": "sha512-3SD4rrMu1msNGEtNSt8Od6enwdo//U9s4ykmXfA2TD58kcLkCobtCDiby7kNyj7a/Q7lz/mAesAFI54rTdnvBA==",
+			"version": "10.2.14",
+			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-10.2.14.tgz",
+			"integrity": "sha512-zkDT5WAF4hSSoUgyfg5tFIxz8XQK+25W/TLVojJTMKBaxevLBBtLxgqguAuVQB8PVW79FVjHcU+GJ9tVbDZ9mQ==",
 			"requires": {
-				"@types/http-cache-semantics": "^4.0.1",
+				"@types/http-cache-semantics": "^4.0.2",
 				"get-stream": "^6.0.1",
 				"http-cache-semantics": "^4.1.1",
 				"keyv": "^4.5.3",
@@ -9679,57 +9369,26 @@
 			}
 		},
 		"call-bind": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-			"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.5.tgz",
+			"integrity": "sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==",
 			"dev": true,
 			"requires": {
-				"function-bind": "^1.1.1",
-				"get-intrinsic": "^1.0.2"
+				"function-bind": "^1.1.2",
+				"get-intrinsic": "^1.2.1",
+				"set-function-length": "^1.1.1"
 			}
 		},
 		"callsites": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/callsites/-/callsites-4.0.0.tgz",
-			"integrity": "sha512-y3jRROutgpKdz5vzEhWM34TidDU8vkJppF8dszITeb1PQmSqV3DTxyV8G/lyO/DNvtE1YTedehmw9MPZsCBHxQ==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/callsites/-/callsites-4.1.0.tgz",
+			"integrity": "sha512-aBMbD1Xxay75ViYezwT40aQONfr+pSXTHwNKvIXhXD6+LY3F1dLIcceoC5OZKBVHbXcysz1hL9D2w0JJIMXpUw==",
 			"dev": true
-		},
-		"camelcase": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-7.0.1.tgz",
-			"integrity": "sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==",
-			"dev": true
-		},
-		"camelcase-keys": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-8.0.2.tgz",
-			"integrity": "sha512-qMKdlOfsjlezMqxkUGGMaWWs17i2HoL15tM+wtx8ld4nLrUwU58TFdvyGOz/piNP842KeO8yXvggVQSdQ828NA==",
-			"dev": true,
-			"requires": {
-				"camelcase": "^7.0.0",
-				"map-obj": "^4.3.0",
-				"quick-lru": "^6.1.1",
-				"type-fest": "^2.13.0"
-			},
-			"dependencies": {
-				"quick-lru": {
-					"version": "6.1.1",
-					"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-6.1.1.tgz",
-					"integrity": "sha512-S27GBT+F0NTRiehtbrgaSE1idUAJ5bX8dPAQTdylEyNlrdcH5X4Lz7Edz3DYzecbsCluD5zO8ZNEe04z3D3u6Q==",
-					"dev": true
-				},
-				"type-fest": {
-					"version": "2.19.0",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-					"integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-					"dev": true
-				}
-			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001518",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001518.tgz",
-			"integrity": "sha512-rup09/e3I0BKjncL+FesTayKtPrdwKhUufQFd3riFw1hHg8JmIFoInYfB102cFcY/pPgGmdyl/iy+jgiDi2vdA==",
+			"version": "1.0.30001566",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001566.tgz",
+			"integrity": "sha512-ggIhCsTxmITBAMmK8yZjEhCO5/47jKXPu6Dha/wuCS4JePVL+3uiDEBuhu2aIoT+bqTOR8L76Ip1ARL9xYsEJA==",
 			"dev": true,
 			"peer": true
 		},
@@ -9778,9 +9437,9 @@
 			"dev": true
 		},
 		"ci-info": {
-			"version": "3.8.0",
-			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.8.0.tgz",
-			"integrity": "sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==",
+			"version": "3.9.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+			"integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
 			"dev": true
 		},
 		"ci-parallel-vars": {
@@ -9954,9 +9613,9 @@
 			}
 		},
 		"convert-source-map": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-			"integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
 			"dev": true
 		},
 		"convert-to-spaces": {
@@ -9966,14 +9625,14 @@
 			"dev": true
 		},
 		"cosmiconfig": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.2.0.tgz",
-			"integrity": "sha512-3rTMnFJA1tCOPwRxtgF4wd7Ab2qvDbL8jX+3smjIbS4HlZBagTlpERbdN7iAbWlrfxE3M8c27kTwTawQ7st+OQ==",
+			"version": "8.3.6",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
+			"integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
 			"dev": true,
 			"requires": {
-				"import-fresh": "^3.2.1",
+				"import-fresh": "^3.3.0",
 				"js-yaml": "^4.1.0",
-				"parse-json": "^5.0.0",
+				"parse-json": "^5.2.0",
 				"path-type": "^4.0.0"
 			},
 			"dependencies": {
@@ -10040,36 +9699,6 @@
 				}
 			}
 		},
-		"decamelize": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-6.0.0.tgz",
-			"integrity": "sha512-Fv96DCsdOgB6mdGl67MT5JaTNKRzrzill5OH5s8bjYJXVlcXyPYGyPsUkWyGV5p1TXI5esYIYMMeDJL0hEIwaA==",
-			"dev": true
-		},
-		"decamelize-keys": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.1.tgz",
-			"integrity": "sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==",
-			"dev": true,
-			"requires": {
-				"decamelize": "^1.1.0",
-				"map-obj": "^1.0.0"
-			},
-			"dependencies": {
-				"decamelize": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-					"integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
-					"dev": true
-				},
-				"map-obj": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-					"integrity": "sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==",
-					"dev": true
-				}
-			}
-		},
 		"decompress-response": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
@@ -10091,15 +9720,103 @@
 			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
 			"dev": true
 		},
+		"default-browser": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/default-browser/-/default-browser-4.0.0.tgz",
+			"integrity": "sha512-wX5pXO1+BrhMkSbROFsyxUm0i/cJEScyNhA4PPxc41ICuv05ZZB/MX28s8aZx6xjmatvebIapF6hLEKEcpneUA==",
+			"dev": true,
+			"requires": {
+				"bundle-name": "^3.0.0",
+				"default-browser-id": "^3.0.0",
+				"execa": "^7.1.1",
+				"titleize": "^3.0.0"
+			},
+			"dependencies": {
+				"execa": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-7.2.0.tgz",
+					"integrity": "sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==",
+					"dev": true,
+					"requires": {
+						"cross-spawn": "^7.0.3",
+						"get-stream": "^6.0.1",
+						"human-signals": "^4.3.0",
+						"is-stream": "^3.0.0",
+						"merge-stream": "^2.0.0",
+						"npm-run-path": "^5.1.0",
+						"onetime": "^6.0.0",
+						"signal-exit": "^3.0.7",
+						"strip-final-newline": "^3.0.0"
+					}
+				},
+				"human-signals": {
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-4.3.1.tgz",
+					"integrity": "sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==",
+					"dev": true
+				},
+				"npm-run-path": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
+					"integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
+					"dev": true,
+					"requires": {
+						"path-key": "^4.0.0"
+					}
+				},
+				"onetime": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+					"integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+					"dev": true,
+					"requires": {
+						"mimic-fn": "^4.0.0"
+					}
+				},
+				"path-key": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+					"integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+					"dev": true
+				},
+				"strip-final-newline": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+					"integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+					"dev": true
+				}
+			}
+		},
+		"default-browser-id": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-3.0.0.tgz",
+			"integrity": "sha512-OZ1y3y0SqSICtE8DE4S8YOE9UZOJ8wO16fKWVP5J1Qz42kV9jcnMVFrEE/noXb/ss3Q4pZIH79kxofzyNNtUNA==",
+			"dev": true,
+			"requires": {
+				"bplist-parser": "^0.2.0",
+				"untildify": "^4.0.0"
+			}
+		},
 		"defaults": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/defaults/-/defaults-2.0.1.tgz",
-			"integrity": "sha512-1bGZaOcfpx0Iyxc0SqSIJ8O2WZF8xm56p4Yd4be+VxYQlFM5/4Mx3IMZqi96Npl8EsBG2pePlyGVLdqsmtIkag=="
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/defaults/-/defaults-2.0.2.tgz",
+			"integrity": "sha512-cuIw0PImdp76AOfgkjbW4VhQODRmNNcKR73vdCH5cLd/ifj7aamfoXvYgfGkEAjNJZ3ozMIy9Gu2LutUkGEPbA=="
 		},
 		"defer-to-connect": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
 			"integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg=="
+		},
+		"define-data-property": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.1.tgz",
+			"integrity": "sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==",
+			"dev": true,
+			"requires": {
+				"get-intrinsic": "^1.2.1",
+				"gopd": "^1.0.1",
+				"has-property-descriptors": "^1.0.0"
+			}
 		},
 		"define-lazy-prop": {
 			"version": "3.0.0",
@@ -10108,76 +9825,14 @@
 			"dev": true
 		},
 		"define-properties": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.0.tgz",
-			"integrity": "sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+			"integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
 			"dev": true,
 			"requires": {
+				"define-data-property": "^1.0.1",
 				"has-property-descriptors": "^1.0.0",
 				"object-keys": "^1.1.1"
-			}
-		},
-		"del": {
-			"version": "6.1.1",
-			"resolved": "https://registry.npmjs.org/del/-/del-6.1.1.tgz",
-			"integrity": "sha512-ua8BhapfP0JUJKC/zV9yHHDW/rDoDxP4Zhn3AkA6/xT6gY7jYXJiaeyBZznYVujhZZET+UgcbZiQ7sN3WqcImg==",
-			"dev": true,
-			"requires": {
-				"globby": "^11.0.1",
-				"graceful-fs": "^4.2.4",
-				"is-glob": "^4.0.1",
-				"is-path-cwd": "^2.2.0",
-				"is-path-inside": "^3.0.2",
-				"p-map": "^4.0.0",
-				"rimraf": "^3.0.2",
-				"slash": "^3.0.0"
-			},
-			"dependencies": {
-				"aggregate-error": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
-					"integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-					"dev": true,
-					"requires": {
-						"clean-stack": "^2.0.0",
-						"indent-string": "^4.0.0"
-					}
-				},
-				"clean-stack": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-					"integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-					"dev": true
-				},
-				"globby": {
-					"version": "11.1.0",
-					"resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-					"integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-					"dev": true,
-					"requires": {
-						"array-union": "^2.1.0",
-						"dir-glob": "^3.0.1",
-						"fast-glob": "^3.2.9",
-						"ignore": "^5.2.0",
-						"merge2": "^1.4.1",
-						"slash": "^3.0.0"
-					}
-				},
-				"indent-string": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-					"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-					"dev": true
-				},
-				"p-map": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-					"integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-					"dev": true,
-					"requires": {
-						"aggregate-error": "^3.0.0"
-					}
-				}
 			}
 		},
 		"dir-glob": {
@@ -10205,16 +9860,16 @@
 			"dev": true
 		},
 		"electron-to-chromium": {
-			"version": "1.4.479",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.479.tgz",
-			"integrity": "sha512-ABv1nHMIR8I5n3O3Een0gr6i0mfM+YcTZqjHy3pAYaOjgFG+BMquuKrSyfYf5CbEkLr9uM05RA3pOk4udNB/aQ==",
+			"version": "1.4.609",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.609.tgz",
+			"integrity": "sha512-ihiCP7PJmjoGNuLpl7TjNA8pCQWu09vGyjlPYw1Rqww4gvNuCcmvl+44G+2QyJ6S2K4o+wbTS++Xz0YN8Q9ERw==",
 			"dev": true,
 			"peer": true
 		},
 		"emittery": {
-			"version": "0.11.0",
-			"resolved": "https://registry.npmjs.org/emittery/-/emittery-0.11.0.tgz",
-			"integrity": "sha512-S/7tzL6v5i+4iJd627Nhv9cLFIo5weAIlGccqJFpnBoDB8U1TF2k5tez4J/QNuxyyhWuFqHg1L84Kd3m7iXg6g==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/emittery/-/emittery-1.0.1.tgz",
+			"integrity": "sha512-2ID6FdrMD9KDLldGesP6317G78K7km/kMcwItRtVFva7I/cSEOIaLpewaUb+YLXVwdAp3Ctfxh/V5zIl1sj7dQ==",
 			"dev": true
 		},
 		"emoji-regex": {
@@ -10259,26 +9914,26 @@
 			}
 		},
 		"es-abstract": {
-			"version": "1.22.1",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.22.1.tgz",
-			"integrity": "sha512-ioRRcXMO6OFyRpyzV3kE1IIBd4WG5/kltnzdxSCqoP8CMGs/Li+M1uF5o7lOkZVFjDs+NLesthnF66Pg/0q0Lw==",
+			"version": "1.22.3",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.22.3.tgz",
+			"integrity": "sha512-eiiY8HQeYfYH2Con2berK+To6GrK2RxbPawDkGq4UiCQQfZHb6wX9qQqkbpPqaxQFcl8d9QzZqo0tGE0VcrdwA==",
 			"dev": true,
 			"requires": {
 				"array-buffer-byte-length": "^1.0.0",
-				"arraybuffer.prototype.slice": "^1.0.1",
+				"arraybuffer.prototype.slice": "^1.0.2",
 				"available-typed-arrays": "^1.0.5",
-				"call-bind": "^1.0.2",
+				"call-bind": "^1.0.5",
 				"es-set-tostringtag": "^2.0.1",
 				"es-to-primitive": "^1.2.1",
-				"function.prototype.name": "^1.1.5",
-				"get-intrinsic": "^1.2.1",
+				"function.prototype.name": "^1.1.6",
+				"get-intrinsic": "^1.2.2",
 				"get-symbol-description": "^1.0.0",
 				"globalthis": "^1.0.3",
 				"gopd": "^1.0.1",
-				"has": "^1.0.3",
 				"has-property-descriptors": "^1.0.0",
 				"has-proto": "^1.0.1",
 				"has-symbols": "^1.0.3",
+				"hasown": "^2.0.0",
 				"internal-slot": "^1.0.5",
 				"is-array-buffer": "^3.0.2",
 				"is-callable": "^1.2.7",
@@ -10286,50 +9941,50 @@
 				"is-regex": "^1.1.4",
 				"is-shared-array-buffer": "^1.0.2",
 				"is-string": "^1.0.7",
-				"is-typed-array": "^1.1.10",
+				"is-typed-array": "^1.1.12",
 				"is-weakref": "^1.0.2",
-				"object-inspect": "^1.12.3",
+				"object-inspect": "^1.13.1",
 				"object-keys": "^1.1.1",
 				"object.assign": "^4.1.4",
-				"regexp.prototype.flags": "^1.5.0",
-				"safe-array-concat": "^1.0.0",
+				"regexp.prototype.flags": "^1.5.1",
+				"safe-array-concat": "^1.0.1",
 				"safe-regex-test": "^1.0.0",
-				"string.prototype.trim": "^1.2.7",
-				"string.prototype.trimend": "^1.0.6",
-				"string.prototype.trimstart": "^1.0.6",
+				"string.prototype.trim": "^1.2.8",
+				"string.prototype.trimend": "^1.0.7",
+				"string.prototype.trimstart": "^1.0.7",
 				"typed-array-buffer": "^1.0.0",
 				"typed-array-byte-length": "^1.0.0",
 				"typed-array-byte-offset": "^1.0.0",
 				"typed-array-length": "^1.0.4",
 				"unbox-primitive": "^1.0.2",
-				"which-typed-array": "^1.1.10"
+				"which-typed-array": "^1.1.13"
 			}
 		},
 		"es-module-lexer": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.3.0.tgz",
-			"integrity": "sha512-vZK7T0N2CBmBOixhmjdqx2gWVbFZ4DXZ/NyRMZVlJXPa7CyFS+/a4QQsDGDQy9ZfEzxFuNEsMLeQJnKP2p5/JA==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.4.1.tgz",
+			"integrity": "sha512-cXLGjP0c4T3flZJKQSuziYoq7MlT+rnvfZjfp7h+I7K9BNX54kP9nyWvdbwjQ4u1iWbOL4u96fgeZLToQlZC7w==",
 			"dev": true,
 			"peer": true
 		},
 		"es-set-tostringtag": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.1.tgz",
-			"integrity": "sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.2.tgz",
+			"integrity": "sha512-BuDyupZt65P9D2D2vA/zqcI3G5xRsklm5N3xCwuiy+/vKy8i0ifdsQP1sLgO4tZDSCaQUSnmC48khknGMV3D2Q==",
 			"dev": true,
 			"requires": {
-				"get-intrinsic": "^1.1.3",
-				"has": "^1.0.3",
-				"has-tostringtag": "^1.0.0"
+				"get-intrinsic": "^1.2.2",
+				"has-tostringtag": "^1.0.0",
+				"hasown": "^2.0.0"
 			}
 		},
 		"es-shim-unscopables": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.0.tgz",
-			"integrity": "sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.2.tgz",
+			"integrity": "sha512-J3yBRXCzDu4ULnQwxyToo/OjdMx6akgVC7K6few0a7F/0wLtmKKN7I73AH5T2836UuXRqN7Qg+IIUw/+YJksRw==",
 			"dev": true,
 			"requires": {
-				"has": "^1.0.3"
+				"hasown": "^2.0.0"
 			}
 		},
 		"es-to-primitive": {
@@ -10352,21 +10007,23 @@
 		"escape-string-regexp": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-			"integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="
+			"integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+			"dev": true
 		},
 		"eslint": {
-			"version": "8.46.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.46.0.tgz",
-			"integrity": "sha512-cIO74PvbW0qU8e0mIvk5IV3ToWdCq5FYG6gWPHHkx6gNdjlbAYvtfHmlCMXxjcoVaIdwy/IAt3+mDkZkfvb2Dg==",
+			"version": "8.55.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.55.0.tgz",
+			"integrity": "sha512-iyUUAM0PCKj5QpwGfmCAG9XXbZCWsqP/eWAWrG/W0umvjuLRBECwSFdt+rCntju0xEH7teIABPwXpahftIaTdA==",
 			"dev": true,
 			"requires": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.6.1",
-				"@eslint/eslintrc": "^2.1.1",
-				"@eslint/js": "^8.46.0",
-				"@humanwhocodes/config-array": "^0.11.10",
+				"@eslint/eslintrc": "^2.1.4",
+				"@eslint/js": "8.55.0",
+				"@humanwhocodes/config-array": "^0.11.13",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@nodelib/fs.walk": "^1.2.8",
+				"@ungap/structured-clone": "^1.2.0",
 				"ajv": "^6.12.4",
 				"chalk": "^4.0.0",
 				"cross-spawn": "^7.0.2",
@@ -10374,7 +10031,7 @@
 				"doctrine": "^3.0.0",
 				"escape-string-regexp": "^4.0.0",
 				"eslint-scope": "^7.2.2",
-				"eslint-visitor-keys": "^3.4.2",
+				"eslint-visitor-keys": "^3.4.3",
 				"espree": "^9.6.1",
 				"esquery": "^1.4.2",
 				"esutils": "^2.0.2",
@@ -10399,23 +10056,6 @@
 				"text-table": "^0.2.0"
 			},
 			"dependencies": {
-				"@eslint/eslintrc": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.1.tgz",
-					"integrity": "sha512-9t7ZA7NGGK8ckelF0PQCfcxIUzs1Md5rrO6U/c+FIQNanea5UZC0wqKXH4vHBccmu4ZJgZ2idtPeW7+Q2npOEA==",
-					"dev": true,
-					"requires": {
-						"ajv": "^6.12.4",
-						"debug": "^4.3.2",
-						"espree": "^9.6.0",
-						"globals": "^13.19.0",
-						"ignore": "^5.2.0",
-						"import-fresh": "^3.2.1",
-						"js-yaml": "^4.1.0",
-						"minimatch": "^3.1.2",
-						"strip-json-comments": "^3.1.1"
-					}
-				},
 				"ansi-regex": {
 					"version": "5.0.1",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -10497,10 +10137,17 @@
 				}
 			}
 		},
+		"eslint-compat-utils": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/eslint-compat-utils/-/eslint-compat-utils-0.1.2.tgz",
+			"integrity": "sha512-Jia4JDldWnFNIru1Ehx1H5s9/yxiRHY/TimCuUc0jNexew3cF1gI6CYZil1ociakfWO3rRqFjl1mskBblB3RYg==",
+			"dev": true,
+			"requires": {}
+		},
 		"eslint-config-prettier": {
-			"version": "8.9.0",
-			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.9.0.tgz",
-			"integrity": "sha512-+sbni7NfVXnOpnRadUA8S28AUlsZt9GjgFvABIRL9Hkn8KqNzOp+7Lw4QWtrwn20KzU3wqu1QoOj2m+7rKRqkA==",
+			"version": "8.10.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.10.0.tgz",
+			"integrity": "sha512-SM8AMJdeQqRYT9O9zguiruQZaN7+z+E4eAP9oiLNGKMtomwaB1E9dcgUD6ZAn/eQAb52USbvezbiljfZUhbJcg==",
 			"dev": true,
 			"requires": {}
 		},
@@ -10512,6 +10159,13 @@
 			"requires": {
 				"confusing-browser-globals": "1.0.11"
 			}
+		},
+		"eslint-config-xo-typescript": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/eslint-config-xo-typescript/-/eslint-config-xo-typescript-1.0.1.tgz",
+			"integrity": "sha512-vPQssnRSUgBFOEfB/KY12CXwltwFSn4RSCfa+w7gjBC2PFQ7Yfgmyei+1XUZ3K+8LRGef2NMJUcxts7PldhDjg==",
+			"dev": true,
+			"requires": {}
 		},
 		"eslint-formatter-pretty": {
 			"version": "5.0.0",
@@ -10613,14 +10267,14 @@
 			}
 		},
 		"eslint-import-resolver-node": {
-			"version": "0.3.7",
-			"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.7.tgz",
-			"integrity": "sha512-gozW2blMLJCeFpBwugLTGyvVjNoeo1knonXAcatC6bjPBZitotxdWf7Gimr25N4c0AAOo4eOUfaG82IJPDpqCA==",
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
+			"integrity": "sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==",
 			"dev": true,
 			"requires": {
 				"debug": "^3.2.7",
-				"is-core-module": "^2.11.0",
-				"resolve": "^1.22.1"
+				"is-core-module": "^2.13.0",
+				"resolve": "^1.22.4"
 			},
 			"dependencies": {
 				"debug": {
@@ -10631,26 +10285,37 @@
 					"requires": {
 						"ms": "^2.1.1"
 					}
+				},
+				"resolve": {
+					"version": "1.22.8",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+					"integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+					"dev": true,
+					"requires": {
+						"is-core-module": "^2.13.0",
+						"path-parse": "^1.0.7",
+						"supports-preserve-symlinks-flag": "^1.0.0"
+					}
 				}
 			}
 		},
 		"eslint-import-resolver-webpack": {
-			"version": "0.13.2",
-			"resolved": "https://registry.npmjs.org/eslint-import-resolver-webpack/-/eslint-import-resolver-webpack-0.13.2.tgz",
-			"integrity": "sha512-XodIPyg1OgE2h5BDErz3WJoK7lawxKTJNhgPNafRST6csC/MZC+L5P6kKqsZGRInpbgc02s/WZMrb4uGJzcuRg==",
+			"version": "0.13.8",
+			"resolved": "https://registry.npmjs.org/eslint-import-resolver-webpack/-/eslint-import-resolver-webpack-0.13.8.tgz",
+			"integrity": "sha512-Y7WIaXWV+Q21Rz/PJgUxiW/FTBOWmU8NTLdz+nz9mMoiz5vAev/fOaQxwD7qRzTfE3HSm1qsxZ5uRd7eX+VEtA==",
 			"dev": true,
 			"requires": {
-				"array-find": "^1.0.0",
+				"array.prototype.find": "^2.2.2",
 				"debug": "^3.2.7",
 				"enhanced-resolve": "^0.9.1",
 				"find-root": "^1.1.0",
-				"has": "^1.0.3",
+				"hasown": "^2.0.0",
 				"interpret": "^1.4.0",
-				"is-core-module": "^2.7.0",
+				"is-core-module": "^2.13.1",
 				"is-regex": "^1.1.4",
 				"lodash": "^4.17.21",
-				"resolve": "^1.20.0",
-				"semver": "^5.7.1"
+				"resolve": "^2.0.0-next.5",
+				"semver": "^5.7.2"
 			},
 			"dependencies": {
 				"debug": {
@@ -10706,31 +10371,15 @@
 				"resolve-from": "^5.0.0"
 			}
 		},
-		"eslint-plugin-es": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-4.1.0.tgz",
-			"integrity": "sha512-GILhQTnjYE2WorX5Jyi5i4dz5ALWxBIdQECVQavL6s7cI76IZTDWleTHkxz/QT3kvcs2QlGHvKLYsSlPOlPXnQ==",
+		"eslint-plugin-es-x": {
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-es-x/-/eslint-plugin-es-x-7.5.0.tgz",
+			"integrity": "sha512-ODswlDSO0HJDzXU0XvgZ3lF3lS3XAZEossh15Q2UHjwrJggWeBoKqqEsLTZLXl+dh5eOAozG0zRcYtuE35oTuQ==",
 			"dev": true,
 			"requires": {
-				"eslint-utils": "^2.0.0",
-				"regexpp": "^3.0.0"
-			},
-			"dependencies": {
-				"eslint-utils": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
-					"integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
-					"dev": true,
-					"requires": {
-						"eslint-visitor-keys": "^1.1.0"
-					}
-				},
-				"eslint-visitor-keys": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-					"integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-					"dev": true
-				}
+				"@eslint-community/eslint-utils": "^4.1.2",
+				"@eslint-community/regexpp": "^4.6.0",
+				"eslint-compat-utils": "^0.1.2"
 			}
 		},
 		"eslint-plugin-eslint-comments": {
@@ -10752,29 +10401,26 @@
 			}
 		},
 		"eslint-plugin-import": {
-			"version": "2.28.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.28.0.tgz",
-			"integrity": "sha512-B8s/n+ZluN7sxj9eUf7/pRFERX0r5bnFA2dCaLHy2ZeaQEAz0k+ZZkFWRFHJAqxfxQDx6KLv9LeIki7cFdwW+Q==",
+			"version": "2.27.5",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.27.5.tgz",
+			"integrity": "sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==",
 			"dev": true,
 			"requires": {
 				"array-includes": "^3.1.6",
-				"array.prototype.findlastindex": "^1.2.2",
 				"array.prototype.flat": "^1.3.1",
 				"array.prototype.flatmap": "^1.3.1",
 				"debug": "^3.2.7",
 				"doctrine": "^2.1.0",
 				"eslint-import-resolver-node": "^0.3.7",
-				"eslint-module-utils": "^2.8.0",
+				"eslint-module-utils": "^2.7.4",
 				"has": "^1.0.3",
-				"is-core-module": "^2.12.1",
+				"is-core-module": "^2.11.0",
 				"is-glob": "^4.0.3",
 				"minimatch": "^3.1.2",
-				"object.fromentries": "^2.0.6",
-				"object.groupby": "^1.0.0",
 				"object.values": "^1.1.6",
-				"resolve": "^1.22.3",
-				"semver": "^6.3.1",
-				"tsconfig-paths": "^3.14.2"
+				"resolve": "^1.22.1",
+				"semver": "^6.3.0",
+				"tsconfig-paths": "^3.14.1"
 			},
 			"dependencies": {
 				"debug": {
@@ -10795,6 +10441,17 @@
 						"esutils": "^2.0.2"
 					}
 				},
+				"resolve": {
+					"version": "1.22.8",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+					"integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+					"dev": true,
+					"requires": {
+						"is-core-module": "^2.13.0",
+						"path-parse": "^1.0.7",
+						"supports-preserve-symlinks-flag": "^1.0.0"
+					}
+				},
 				"semver": {
 					"version": "6.3.1",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -10804,19 +10461,34 @@
 			}
 		},
 		"eslint-plugin-n": {
-			"version": "15.7.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-15.7.0.tgz",
-			"integrity": "sha512-jDex9s7D/Qial8AGVIHq4W7NswpUD5DPDL2RH8Lzd9EloWUuvUkHfv4FRLMipH5q2UtyurorBkPeNi1wVWNh3Q==",
+			"version": "16.3.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-16.3.1.tgz",
+			"integrity": "sha512-w46eDIkxQ2FaTHcey7G40eD+FhTXOdKudDXPUO2n9WNcslze/i/HT2qJ3GXjHngYSGDISIgPNhwGtgoix4zeOw==",
 			"dev": true,
 			"requires": {
+				"@eslint-community/eslint-utils": "^4.4.0",
 				"builtins": "^5.0.1",
-				"eslint-plugin-es": "^4.1.0",
-				"eslint-utils": "^3.0.0",
-				"ignore": "^5.1.1",
-				"is-core-module": "^2.11.0",
+				"eslint-plugin-es-x": "^7.1.0",
+				"get-tsconfig": "^4.7.0",
+				"ignore": "^5.2.4",
+				"is-builtin-module": "^3.2.1",
+				"is-core-module": "^2.12.1",
 				"minimatch": "^3.1.2",
-				"resolve": "^1.22.1",
-				"semver": "^7.3.8"
+				"resolve": "^1.22.2",
+				"semver": "^7.5.3"
+			},
+			"dependencies": {
+				"resolve": {
+					"version": "1.22.8",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+					"integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+					"dev": true,
+					"requires": {
+						"is-core-module": "^2.13.0",
+						"path-parse": "^1.0.7",
+						"supports-preserve-symlinks-flag": "^1.0.0"
+					}
+				}
 			}
 		},
 		"eslint-plugin-no-use-extend-native": {
@@ -10832,35 +10504,35 @@
 			}
 		},
 		"eslint-plugin-prettier": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz",
-			"integrity": "sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.0.1.tgz",
+			"integrity": "sha512-m3u5RnR56asrwV/lDC4GHorlW75DsFfmUcjfCYylTUs85dBRnB7VM6xG8eCMJdeDRnppzmxZVf1GEPJvl1JmNg==",
 			"dev": true,
 			"requires": {
-				"prettier-linter-helpers": "^1.0.0"
+				"prettier-linter-helpers": "^1.0.0",
+				"synckit": "^0.8.5"
 			}
 		},
 		"eslint-plugin-unicorn": {
-			"version": "46.0.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-46.0.1.tgz",
-			"integrity": "sha512-setGhMTiLAddg1asdwjZ3hekIN5zLznNa5zll7pBPwFOka6greCKDQydfqy4fqyUhndi74wpDzClSQMEcmOaew==",
+			"version": "48.0.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-48.0.1.tgz",
+			"integrity": "sha512-FW+4r20myG/DqFcCSzoumaddKBicIPeFnTrifon2mWIzlfyvzwyqZjqVP7m4Cqr/ZYisS2aiLghkUWaPg6vtCw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-validator-identifier": "^7.19.1",
-				"@eslint-community/eslint-utils": "^4.1.2",
-				"ci-info": "^3.6.1",
+				"@babel/helper-validator-identifier": "^7.22.5",
+				"@eslint-community/eslint-utils": "^4.4.0",
+				"ci-info": "^3.8.0",
 				"clean-regexp": "^1.0.0",
-				"esquery": "^1.4.0",
+				"esquery": "^1.5.0",
 				"indent-string": "^4.0.0",
-				"is-builtin-module": "^3.2.0",
+				"is-builtin-module": "^3.2.1",
 				"jsesc": "^3.0.2",
 				"lodash": "^4.17.21",
 				"pluralize": "^8.0.0",
 				"read-pkg-up": "^7.0.1",
-				"regexp-tree": "^0.1.24",
-				"regjsparser": "^0.9.1",
-				"safe-regex": "^2.1.1",
-				"semver": "^7.3.8",
+				"regexp-tree": "^0.1.27",
+				"regjsparser": "^0.10.0",
+				"semver": "^7.5.4",
 				"strip-indent": "^3.0.0"
 			},
 			"dependencies": {
@@ -10906,19 +10578,19 @@
 			}
 		},
 		"eslint-visitor-keys": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.2.tgz",
-			"integrity": "sha512-8drBzUEyZ2llkpCA67iYrgEssKDUu68V8ChqqOfFupIaG/LCVPUT+CoGJpT77zJprs4T/W7p07LP7zAIMuweVw==",
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+			"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
 			"dev": true
 		},
 		"esm-utils": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/esm-utils/-/esm-utils-4.1.2.tgz",
-			"integrity": "sha512-hYKPzOCkAU11rMIiH6gvvReARaSLiRhJkGWPcwJB/S4zg7em//YKAcRxwZYw4sW5mRmI6lhV59wWWTdWKwOXvQ==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/esm-utils/-/esm-utils-4.2.1.tgz",
+			"integrity": "sha512-a7t8pDmZ5MeYfo2pM5EcqeU+BqKobUFKnWkM17JOhTlR88OSosLa9Ak4bgm+htoF15HRf7tfrXNR62UogmIODg==",
 			"dev": true,
 			"requires": {
-				"import-meta-resolve": "2.2.2",
-				"url-or-path": "2.1.0"
+				"import-meta-resolve": "^4.0.0",
+				"url-or-path": "^2.1.0"
 			}
 		},
 		"espree": {
@@ -11036,14 +10708,14 @@
 			"dev": true
 		},
 		"fast-fifo": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.0.tgz",
-			"integrity": "sha512-IgfweLvEpwyA4WgiQe9Nx6VV2QkML2NkvZnk1oKnIzXgXdWxuhF7zw4DvLTPZJn6PIUneiAXPF24QmoEqHTjyw=="
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+			"integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="
 		},
 		"fast-glob": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
-			"integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+			"integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
 			"dev": true,
 			"requires": {
 				"@nodelib/fs.stat": "^2.0.2",
@@ -11083,9 +10755,9 @@
 			}
 		},
 		"figures": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/figures/-/figures-4.0.1.tgz",
-			"integrity": "sha512-rElJwkA/xS04Vfg+CaZodpso7VqBknOYbzi6I76hI4X80RUjkSxO2oAyPmGbuXUppywjqndOrQDl817hDnI++w==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/figures/-/figures-5.0.0.tgz",
+			"integrity": "sha512-ej8ksPF4x6e5wvK9yevct0UCXh8TTFlWGVLlgjZuoBH1HwjIfKE/IdL5mq89sFA7zELi1VhKpmtDnrs7zWyeyg==",
 			"dev": true,
 			"requires": {
 				"escape-string-regexp": "^5.0.0",
@@ -11102,9 +10774,9 @@
 			}
 		},
 		"file-type": {
-			"version": "18.5.0",
-			"resolved": "https://registry.npmjs.org/file-type/-/file-type-18.5.0.tgz",
-			"integrity": "sha512-yvpl5U868+V6PqXHMmsESpg6unQ5GfnPssl4dxdJudBrr9qy7Fddt7EVX1VLlddFfe8Gj9N7goCZH22FXuSQXQ==",
+			"version": "18.7.0",
+			"resolved": "https://registry.npmjs.org/file-type/-/file-type-18.7.0.tgz",
+			"integrity": "sha512-ihHtXRzXEziMrQ56VSgU7wkxh55iNchFkosu7Y9/S+tXHdKyrGjVK0ujbqNnsxzea+78MaLhN6PGmfYSAv1ACw==",
 			"requires": {
 				"readable-web-to-node-stream": "^3.0.2",
 				"strtok3": "^7.0.0",
@@ -11117,13 +10789,11 @@
 			"integrity": "sha512-hn4cQfU6GOT/7cFHXBqeBg2TbrMBgdD0kcjLhvSQYYwm3s4B6cjvBfb7nBALJLAXqmU5xajSa7X2NnUud/VCdw=="
 		},
 		"filenamify": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/filenamify/-/filenamify-5.1.1.tgz",
-			"integrity": "sha512-M45CbrJLGACfrPOkrTp3j2EcO9OBkKUYME0eiqOCa7i2poaklU0jhlIaMlr8ijLorT0uLAzrn3qXOp5684CkfA==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/filenamify/-/filenamify-6.0.0.tgz",
+			"integrity": "sha512-vqIlNogKeyD3yzrm0yhRMQg8hOVwYcYRfjEoODd49iCprMn4HL85gK3HcykQE53EPIpX3HcAbGA5ELQv216dAQ==",
 			"requires": {
-				"filename-reserved-regex": "^3.0.0",
-				"strip-outer": "^2.0.0",
-				"trim-repeated": "^2.0.0"
+				"filename-reserved-regex": "^3.0.0"
 			}
 		},
 		"fill-range": {
@@ -11224,19 +10894,20 @@
 			}
 		},
 		"flat-cache": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
-			"integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
+			"integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
 			"dev": true,
 			"requires": {
-				"flatted": "^3.1.0",
+				"flatted": "^3.2.9",
+				"keyv": "^4.5.3",
 				"rimraf": "^3.0.2"
 			}
 		},
 		"flatted": {
-			"version": "3.2.7",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
-			"integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
+			"version": "3.2.9",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.9.tgz",
+			"integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==",
 			"dev": true
 		},
 		"for-each": {
@@ -11270,28 +10941,28 @@
 			"dev": true
 		},
 		"fsevents": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
 			"dev": true,
 			"optional": true
 		},
 		"function-bind": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
 			"dev": true
 		},
 		"function.prototype.name": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
-			"integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.6.tgz",
+			"integrity": "sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==",
 			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.19.0",
-				"functions-have-names": "^1.2.2"
+				"define-properties": "^1.2.0",
+				"es-abstract": "^1.22.1",
+				"functions-have-names": "^1.2.3"
 			}
 		},
 		"functions-have-names": {
@@ -11307,15 +10978,15 @@
 			"dev": true
 		},
 		"get-intrinsic": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
-			"integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.2.tgz",
+			"integrity": "sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==",
 			"dev": true,
 			"requires": {
-				"function-bind": "^1.1.1",
-				"has": "^1.0.3",
+				"function-bind": "^1.1.2",
 				"has-proto": "^1.0.1",
-				"has-symbols": "^1.0.3"
+				"has-symbols": "^1.0.3",
+				"hasown": "^2.0.0"
 			}
 		},
 		"get-set-props": {
@@ -11346,9 +11017,9 @@
 			}
 		},
 		"get-tsconfig": {
-			"version": "4.6.2",
-			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.6.2.tgz",
-			"integrity": "sha512-E5XrT4CbbXcXWy+1jChlZmrmCwd5KGx502kDCXJJ7y898TtWW9FwoG5HfOLVRKmlmDGkWN2HM9Ho+/Y8F0sJDg==",
+			"version": "4.7.2",
+			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.7.2.tgz",
+			"integrity": "sha512-wuMsz4leaj5hbGgg4IvDU0bqJagpftG5l5cXIAvo8uZrqn0NJqwtfupTN00VnkQJPcIRrxYrm1Ue24btpCha2A==",
 			"dev": true,
 			"requires": {
 				"resolve-pkg-maps": "^1.0.0"
@@ -11385,9 +11056,9 @@
 			"peer": true
 		},
 		"globals": {
-			"version": "13.20.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
-			"integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
+			"version": "13.23.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-13.23.0.tgz",
+			"integrity": "sha512-XAmF0RjlrjY23MA51q3HltdlGxUpXPvg0GioKiD9X6HD28iMjo2dKC8Vqwm7lne4GNr78+RHTfliktR6ZH09wA==",
 			"dev": true,
 			"requires": {
 				"type-fest": "^0.20.2"
@@ -11421,14 +11092,6 @@
 				"ignore": "^5.2.4",
 				"merge2": "^1.4.1",
 				"slash": "^4.0.0"
-			},
-			"dependencies": {
-				"slash": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
-					"integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
-					"dev": true
-				}
 			}
 		},
 		"gopd": {
@@ -11441,9 +11104,9 @@
 			}
 		},
 		"got": {
-			"version": "12.6.1",
-			"resolved": "https://registry.npmjs.org/got/-/got-12.6.1.tgz",
-			"integrity": "sha512-mThBblvlAF1d4O5oqyvN+ZxLAYwIJK7bpMxgYqPD9okW0C3qm5FFn7k811QrcuEBwaogR3ngOFoCfs6mRv7teQ==",
+			"version": "13.0.0",
+			"resolved": "https://registry.npmjs.org/got/-/got-13.0.0.tgz",
+			"integrity": "sha512-XfBk1CxOOScDcMr9O1yKkNaQyy865NbYs+F7dr4H0LZMVgCj2Le59k6PqbNHoL5ToeaEQUYh6c6yMfVcc6SJxA==",
 			"requires": {
 				"@sindresorhus/is": "^5.2.0",
 				"@szmarczak/http-timer": "^5.0.1",
@@ -11469,20 +11132,11 @@
 			"integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
 			"dev": true
 		},
-		"hard-rejection": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
-			"integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
-			"dev": true
-		},
 		"has": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-			"dev": true,
-			"requires": {
-				"function-bind": "^1.1.1"
-			}
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/has/-/has-1.0.4.tgz",
+			"integrity": "sha512-qdSAmqLF6209RFj4VVItywPMbm3vWylknmB3nvNiUIs72xAimcM8nVYxYr7ncvZq5qzk9MKIZR8ijqD/1QuYjQ==",
+			"dev": true
 		},
 		"has-bigints": {
 			"version": "1.0.2",
@@ -11497,12 +11151,12 @@
 			"dev": true
 		},
 		"has-property-descriptors": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
-			"integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz",
+			"integrity": "sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==",
 			"dev": true,
 			"requires": {
-				"get-intrinsic": "^1.1.1"
+				"get-intrinsic": "^1.2.2"
 			}
 		},
 		"has-proto": {
@@ -11526,22 +11180,20 @@
 				"has-symbols": "^1.0.2"
 			}
 		},
-		"hosted-git-info": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-5.2.1.tgz",
-			"integrity": "sha512-xIcQYMnhcx2Nr4JTjsFmwwnr9vldugPy9uVm0o87bjqqWMv9GaqsTeT+i99wTl0mk1uLxJtHxLb8kymqTENQsw==",
+		"hasown": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
+			"integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
 			"dev": true,
 			"requires": {
-				"lru-cache": "^7.5.1"
-			},
-			"dependencies": {
-				"lru-cache": {
-					"version": "7.18.3",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-					"integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-					"dev": true
-				}
+				"function-bind": "^1.1.2"
 			}
+		},
+		"hosted-git-info": {
+			"version": "2.8.9",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+			"integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+			"dev": true
 		},
 		"html-escaper": {
 			"version": "2.0.2",
@@ -11555,9 +11207,9 @@
 			"integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
 		},
 		"http2-wrapper": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.0.tgz",
-			"integrity": "sha512-kZB0wxMo0sh1PehyjJUWRFEd99KC5TLjZ2cULC4f9iqJBAmKQQXEICjxl5iPJRwP40dpeHFqqhm7tYCvODpqpQ==",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.1.tgz",
+			"integrity": "sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==",
 			"requires": {
 				"quick-lru": "^5.1.1",
 				"resolve-alpn": "^1.2.0"
@@ -11575,9 +11227,9 @@
 			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
 		},
 		"ignore": {
-			"version": "5.2.4",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
-			"integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.0.tgz",
+			"integrity": "sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==",
 			"dev": true
 		},
 		"ignore-by-default": {
@@ -11605,9 +11257,9 @@
 			}
 		},
 		"import-meta-resolve": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-2.2.2.tgz",
-			"integrity": "sha512-f8KcQ1D80V7RnqVm+/lirO9zkOxjGxhaTC1IPrBGd3MEfNgmNG67tSUO9gTi2F3Blr2Az6g1vocaxzkVnWl9MA==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.0.0.tgz",
+			"integrity": "sha512-okYUR7ZQPH+efeuMJGlq4f8ubUgO50kByRPyt/Cy1Io4PSRsPjxME+YlVaCOx+NIToW7hCsZNFJyTPFFKepRSA==",
 			"dev": true
 		},
 		"import-modules": {
@@ -11652,13 +11304,13 @@
 			}
 		},
 		"internal-slot": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.5.tgz",
-			"integrity": "sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.6.tgz",
+			"integrity": "sha512-Xj6dv+PsbtwyPpEflsejS+oIZxmMlV44zAhG479uYu89MsjcYOhCFnNyKrkJrihbsiasQyY0afoCl/9BLR65bg==",
 			"dev": true,
 			"requires": {
-				"get-intrinsic": "^1.2.0",
-				"has": "^1.0.3",
+				"get-intrinsic": "^1.2.2",
+				"hasown": "^2.0.0",
 				"side-channel": "^1.0.4"
 			}
 		},
@@ -11745,12 +11397,12 @@
 			"dev": true
 		},
 		"is-core-module": {
-			"version": "2.12.1",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.1.tgz",
-			"integrity": "sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==",
+			"version": "2.13.1",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
+			"integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
 			"dev": true,
 			"requires": {
-				"has": "^1.0.3"
+				"hasown": "^2.0.0"
 			}
 		},
 		"is-date-object": {
@@ -11813,6 +11465,23 @@
 				"is-extglob": "^2.1.1"
 			}
 		},
+		"is-inside-container": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+			"integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+			"dev": true,
+			"requires": {
+				"is-docker": "^3.0.0"
+			},
+			"dependencies": {
+				"is-docker": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+					"integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+					"dev": true
+				}
+			}
+		},
 		"is-js-type": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-js-type/-/is-js-type-2.0.0.tgz",
@@ -11867,17 +11536,16 @@
 				}
 			}
 		},
-		"is-path-cwd": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
-			"integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
-			"dev": true
-		},
 		"is-path-inside": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
 			"integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
 			"dev": true
+		},
+		"is-plain-obj": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+			"integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg=="
 		},
 		"is-plain-object": {
 			"version": "5.0.0",
@@ -12027,9 +11695,9 @@
 			"dev": true
 		},
 		"istanbul-lib-coverage": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz",
-			"integrity": "sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==",
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+			"integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
 			"dev": true
 		},
 		"istanbul-lib-report": {
@@ -12150,9 +11818,9 @@
 			}
 		},
 		"keyv": {
-			"version": "4.5.3",
-			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.3.tgz",
-			"integrity": "sha512-QCiSav9WaX1PgETJ+SpNnx2PRRapJ/oRSXM4VO5OGYGSjrxbKPVFVhB3l2OCbLCk329N8qyAtsJjSjvVBWzEug==",
+			"version": "4.5.4",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+			"integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
 			"requires": {
 				"json-buffer": "3.0.1"
 			}
@@ -12317,12 +11985,6 @@
 				"p-defer": "^1.0.0"
 			}
 		},
-		"map-obj": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
-			"integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
-			"dev": true
-		},
 		"matcher": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/matcher/-/matcher-5.0.0.tgz",
@@ -12358,135 +12020,10 @@
 			"dev": true
 		},
 		"meow": {
-			"version": "11.0.0",
-			"resolved": "https://registry.npmjs.org/meow/-/meow-11.0.0.tgz",
-			"integrity": "sha512-Cl0yeeIrko6d94KpUo1M+0X1sB14ikoaqlIGuTH1fW4I+E3+YljL54/hb/BWmVfrV9tTV9zU04+xjw08Fh2WkA==",
-			"dev": true,
-			"requires": {
-				"@types/minimist": "^1.2.2",
-				"camelcase-keys": "^8.0.2",
-				"decamelize": "^6.0.0",
-				"decamelize-keys": "^1.1.0",
-				"hard-rejection": "^2.1.0",
-				"minimist-options": "4.1.0",
-				"normalize-package-data": "^4.0.1",
-				"read-pkg-up": "^9.1.0",
-				"redent": "^4.0.0",
-				"trim-newlines": "^4.0.2",
-				"type-fest": "^3.1.0",
-				"yargs-parser": "^21.1.1"
-			},
-			"dependencies": {
-				"find-up": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-6.3.0.tgz",
-					"integrity": "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^7.1.0",
-						"path-exists": "^5.0.0"
-					}
-				},
-				"hosted-git-info": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
-					"integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
-					"integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^6.0.0"
-					}
-				},
-				"p-limit": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
-					"integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
-					"dev": true,
-					"requires": {
-						"yocto-queue": "^1.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
-					"integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
-					"dev": true,
-					"requires": {
-						"p-limit": "^4.0.0"
-					}
-				},
-				"read-pkg": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-7.1.0.tgz",
-					"integrity": "sha512-5iOehe+WF75IccPc30bWTbpdDQLOCc3Uu8bi3Dte3Eueij81yx1Mrufk8qBx/YAbR4uL1FdUr+7BKXDwEtisXg==",
-					"dev": true,
-					"requires": {
-						"@types/normalize-package-data": "^2.4.1",
-						"normalize-package-data": "^3.0.2",
-						"parse-json": "^5.2.0",
-						"type-fest": "^2.0.0"
-					},
-					"dependencies": {
-						"normalize-package-data": {
-							"version": "3.0.3",
-							"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
-							"integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
-							"dev": true,
-							"requires": {
-								"hosted-git-info": "^4.0.1",
-								"is-core-module": "^2.5.0",
-								"semver": "^7.3.4",
-								"validate-npm-package-license": "^3.0.1"
-							}
-						},
-						"type-fest": {
-							"version": "2.19.0",
-							"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-							"integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-							"dev": true
-						}
-					}
-				},
-				"read-pkg-up": {
-					"version": "9.1.0",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-9.1.0.tgz",
-					"integrity": "sha512-vaMRR1AC1nrd5CQM0PhlRsO5oc2AAigqr7cCrZ/MW/Rsaflz4RlgzkpL4qoU/z1F6wrbd85iFv1OQj/y5RdGvg==",
-					"dev": true,
-					"requires": {
-						"find-up": "^6.3.0",
-						"read-pkg": "^7.1.0",
-						"type-fest": "^2.5.0"
-					},
-					"dependencies": {
-						"type-fest": {
-							"version": "2.19.0",
-							"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-							"integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-							"dev": true
-						}
-					}
-				},
-				"type-fest": {
-					"version": "3.13.1",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
-					"integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==",
-					"dev": true
-				},
-				"yocto-queue": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
-					"integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
-					"dev": true
-				}
-			}
+			"version": "12.1.1",
+			"resolved": "https://registry.npmjs.org/meow/-/meow-12.1.1.tgz",
+			"integrity": "sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==",
+			"dev": true
 		},
 		"merge-stream": {
 			"version": "2.0.0",
@@ -12563,31 +12100,6 @@
 			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
 			"dev": true
 		},
-		"minimist-options": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
-			"integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
-			"dev": true,
-			"requires": {
-				"arrify": "^1.0.1",
-				"is-plain-obj": "^1.1.0",
-				"kind-of": "^6.0.3"
-			},
-			"dependencies": {
-				"arrify": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-					"integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
-					"dev": true
-				},
-				"is-plain-obj": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-					"integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
-					"dev": true
-				}
-			}
-		},
 		"ms": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -12608,21 +12120,20 @@
 			"peer": true
 		},
 		"nock": {
-			"version": "13.3.2",
-			"resolved": "https://registry.npmjs.org/nock/-/nock-13.3.2.tgz",
-			"integrity": "sha512-CwbljitiWJhF1gL83NbanhoKs1l23TDlRioNraPTZrzZIEooPemrHRj5m0FZCPkB1ecdYCSWWGcHysJgX/ngnQ==",
+			"version": "13.4.0",
+			"resolved": "https://registry.npmjs.org/nock/-/nock-13.4.0.tgz",
+			"integrity": "sha512-W8NVHjO/LCTNA64yxAPHV/K47LpGYcVzgKd3Q0n6owhwvD0Dgoterc25R4rnZbckJEb6Loxz1f5QMuJpJnbSyQ==",
 			"dev": true,
 			"requires": {
 				"debug": "^4.1.0",
 				"json-stringify-safe": "^5.0.1",
-				"lodash": "^4.17.21",
 				"propagate": "^2.0.0"
 			}
 		},
 		"node-releases": {
-			"version": "2.0.13",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
-			"integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
+			"version": "2.0.14",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
+			"integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
 			"dev": true,
 			"peer": true
 		},
@@ -12633,15 +12144,34 @@
 			"dev": true
 		},
 		"normalize-package-data": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-4.0.1.tgz",
-			"integrity": "sha512-EBk5QKKuocMJhB3BILuKhmaPjI8vNRSpIfO9woLC6NyHVkKKdVEdAO1mrT0ZfxNR1lKwCcTkuZfmGIFdizZ8Pg==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+			"integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
 			"dev": true,
 			"requires": {
-				"hosted-git-info": "^5.0.0",
-				"is-core-module": "^2.8.1",
-				"semver": "^7.3.5",
-				"validate-npm-package-license": "^3.0.4"
+				"hosted-git-info": "^2.1.4",
+				"resolve": "^1.10.0",
+				"semver": "2 || 3 || 4 || 5",
+				"validate-npm-package-license": "^3.0.1"
+			},
+			"dependencies": {
+				"resolve": {
+					"version": "1.22.8",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+					"integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+					"dev": true,
+					"requires": {
+						"is-core-module": "^2.13.0",
+						"path-parse": "^1.0.7",
+						"supports-preserve-symlinks-flag": "^1.0.0"
+					}
+				},
+				"semver": {
+					"version": "5.7.2",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+					"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+					"dev": true
+				}
 			}
 		},
 		"normalize-path": {
@@ -12671,9 +12201,9 @@
 			"dev": true
 		},
 		"object-inspect": {
-			"version": "1.12.3",
-			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
-			"integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
+			"version": "1.13.1",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
+			"integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
 			"dev": true
 		},
 		"object-keys": {
@@ -12683,49 +12213,26 @@
 			"dev": true
 		},
 		"object.assign": {
-			"version": "4.1.4",
-			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
-			"integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.5.tgz",
+			"integrity": "sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==",
 			"dev": true,
 			"requires": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.4",
+				"call-bind": "^1.0.5",
+				"define-properties": "^1.2.1",
 				"has-symbols": "^1.0.3",
 				"object-keys": "^1.1.1"
 			}
 		},
-		"object.fromentries": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.6.tgz",
-			"integrity": "sha512-VciD13dswC4j1Xt5394WR4MzmAQmlgN72phd/riNp9vtD7tp4QQWJ0R4wvclXcafgcYK8veHRed2W6XeGBvcfg==",
-			"dev": true,
-			"requires": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.4",
-				"es-abstract": "^1.20.4"
-			}
-		},
-		"object.groupby": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.0.tgz",
-			"integrity": "sha512-70MWG6NfRH9GnbZOikuhPPYzpUpof9iW2J9E4dW7FXTqPNb6rllE6u39SKwwiNh8lCwX3DDb5OgcKGiEBrTTyw==",
+		"object.values": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.7.tgz",
+			"integrity": "sha512-aU6xnDFYT3x17e/f0IiiwlGPTy2jzMySGfUB4fq6z7CV8l85CWHDk5ErhyhpfDHhrOMwGFhSQkhMGHaIotA6Ng==",
 			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.2.0",
-				"es-abstract": "^1.21.2",
-				"get-intrinsic": "^1.2.1"
-			}
-		},
-		"object.values": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.6.tgz",
-			"integrity": "sha512-FVVTkD1vENCsAcwNs9k6jea2uHC/X0+JcjG8YA60FN5CMaJmG95wT9jek/xX9nornqGRrBkKtzuAu2wuHpKqvw==",
-			"dev": true,
-			"requires": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.4",
-				"es-abstract": "^1.20.4"
+				"es-abstract": "^1.22.1"
 			}
 		},
 		"once": {
@@ -12774,12 +12281,12 @@
 			}
 		},
 		"open-editor": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/open-editor/-/open-editor-4.0.0.tgz",
-			"integrity": "sha512-5mKZ98iFdkivozt5XTCOspoKbL3wtYu6oOoVxfWQ0qUX9NYsK8pdkHE7VUHXr+CwyC3nf6mV0S5FPsMS65innw==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/open-editor/-/open-editor-4.1.1.tgz",
+			"integrity": "sha512-SYtGeZ9Zkzj/naoZaEF9LzwDYEGwuqQ4Fx5E3xdVRN98LFJjvMhG/ElByFEOVOiXepGra/Wi1fA4i/E1fXSBsw==",
 			"dev": true,
 			"requires": {
-				"env-editor": "^1.0.0",
+				"env-editor": "^1.1.0",
 				"execa": "^5.1.1",
 				"line-column-path": "^3.0.0",
 				"open": "^8.4.0"
@@ -12811,11 +12318,11 @@
 			"dev": true
 		},
 		"p-event": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/p-event/-/p-event-5.0.1.tgz",
-			"integrity": "sha512-dd589iCQ7m1L0bmC5NLlVYfy3TbBEsMUfWx9PyAgPeIcFZ/E2yaTZ4Rz4MiBmmJShviiftHVXOqfnfzJ6kyMrQ==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/p-event/-/p-event-6.0.0.tgz",
+			"integrity": "sha512-Xbfxd0CfZmHLGKXH32k1JKjQYX6Rkv0UtQdaFJ8OyNcf+c0oWCeXHc1C4CX/IESZLmcvfPa5aFIO/vCr5gqtag==",
 			"requires": {
-				"p-timeout": "^5.0.2"
+				"p-timeout": "^6.1.2"
 			}
 		},
 		"p-limit": {
@@ -12846,9 +12353,9 @@
 			}
 		},
 		"p-timeout": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-5.1.0.tgz",
-			"integrity": "sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew=="
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.2.tgz",
+			"integrity": "sha512-UbD77BuZ9Bc9aABo74gfXhNvzC9Tx7SxtHSh1fxvx3jTLLYvmVhiQZZrJzqqU0jKbN32kb5VOKiLEQI/3bIjgQ=="
 		},
 		"p-try": {
 			"version": "2.2.0",
@@ -12886,9 +12393,9 @@
 			}
 		},
 		"parse-ms": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-2.1.0.tgz",
-			"integrity": "sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-3.0.0.tgz",
+			"integrity": "sha512-Tpb8Z7r7XbbtBTrM9UhpkzzaMrqA2VXMT3YChzYltwV3P3pM6t8wl7TvpMnSTosz1aQAdVib7kdoys7vYOPerw==",
 			"dev": true
 		},
 		"path-exists": {
@@ -12935,8 +12442,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
 			"integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"picomatch": {
 			"version": "2.3.1",
@@ -13030,9 +12536,9 @@
 			"dev": true
 		},
 		"prettier": {
-			"version": "2.8.8",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-			"integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.0.tgz",
+			"integrity": "sha512-TQLvXjq5IAibjh8EpBIkNKxO749UEWABoiIZehEPiY4GNpVdhaFKqSTu+QrlU6D2dPAfubRmtJTi4K4YkQ5eXw==",
 			"dev": true
 		},
 		"prettier-linter-helpers": {
@@ -13045,12 +12551,12 @@
 			}
 		},
 		"pretty-ms": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-7.0.1.tgz",
-			"integrity": "sha512-973driJZvxiGOQ5ONsFhOF/DtzPMOMtgC11kCpUrPGMTgqp2q/1gwzCquocrN33is0VZ5GFHXZYMM9l6h67v2Q==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-8.0.0.tgz",
+			"integrity": "sha512-ASJqOugUF1bbzI35STMBUpZqdfYKlJugy6JBziGi2EE+AL5JPJGSzvpeVXojxrr0ViUYoToUjb5kjSEGf7Y83Q==",
 			"dev": true,
 			"requires": {
-				"parse-ms": "^2.1.0"
+				"parse-ms": "^3.0.0"
 			}
 		},
 		"propagate": {
@@ -13066,9 +12572,9 @@
 			"dev": true
 		},
 		"punycode": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-			"integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
 			"dev": true
 		},
 		"queue-microtask": {
@@ -13109,30 +12615,6 @@
 				"type-fest": "^0.6.0"
 			},
 			"dependencies": {
-				"hosted-git-info": {
-					"version": "2.8.9",
-					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-					"integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
-					"dev": true
-				},
-				"normalize-package-data": {
-					"version": "2.5.0",
-					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-					"integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-					"dev": true,
-					"requires": {
-						"hosted-git-info": "^2.1.4",
-						"resolve": "^1.10.0",
-						"semver": "2 || 3 || 4 || 5",
-						"validate-npm-package-license": "^3.0.1"
-					}
-				},
-				"semver": {
-					"version": "5.7.2",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-					"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-					"dev": true
-				},
 				"type-fest": {
 					"version": "0.6.0",
 					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
@@ -13230,27 +12712,6 @@
 				"picomatch": "^2.2.1"
 			}
 		},
-		"redent": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/redent/-/redent-4.0.0.tgz",
-			"integrity": "sha512-tYkDkVVtYkSVhuQ4zBgfvciymHaeuel+zFKXShfDnFP5SyVEP7qo70Rf1jTOTCx3vGNAbnEi/xFkcfQVMIBWag==",
-			"dev": true,
-			"requires": {
-				"indent-string": "^5.0.0",
-				"strip-indent": "^4.0.0"
-			},
-			"dependencies": {
-				"strip-indent": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.0.0.tgz",
-					"integrity": "sha512-mnVSV2l+Zv6BLpSD/8V87CW/y9EmmbYzGCIavsnsI6/nwn26DwffM/yztm30Z/I2DY9wdS3vXVCMnHDgZaVNoA==",
-					"dev": true,
-					"requires": {
-						"min-indent": "^1.0.1"
-					}
-				}
-			}
-		},
 		"regexp-tree": {
 			"version": "0.1.27",
 			"resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
@@ -13258,26 +12719,20 @@
 			"dev": true
 		},
 		"regexp.prototype.flags": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.0.tgz",
-			"integrity": "sha512-0SutC3pNudRKgquxGoRGIz946MZVHqbNfPjBdxeOhBrdgDKlRoXmYLQN9xRbrR09ZXWeGAdPuif7egofn6v5LA==",
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.1.tgz",
+			"integrity": "sha512-sy6TXMN+hnP/wMy+ISxg3krXx7BAtWVO4UouuCN/ziM9UEne0euamVNafDfvC83bRNr95y0V5iijeDQFUNpvrg==",
 			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.2.0",
-				"functions-have-names": "^1.2.3"
+				"set-function-name": "^2.0.0"
 			}
 		},
-		"regexpp": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
-			"integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
-			"dev": true
-		},
 		"regjsparser": {
-			"version": "0.9.1",
-			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.9.1.tgz",
-			"integrity": "sha512-dQUtn90WanSNl+7mQKcXAgZxvUe7Z0SqXlgzv0za4LwiUhyzBC58yQO3liFoUgu8GiJVInAhJjkj1N0EtQ5nkQ==",
+			"version": "0.10.0",
+			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.10.0.tgz",
+			"integrity": "sha512-qx+xQGZVsy55CH0a1hiVwHmqjLryfh7wQyF5HO07XJ9f7dQMY/gPQHhlyDkIzJKC+x2fUCpCcUODUUUFrm7SHA==",
 			"dev": true,
 			"requires": {
 				"jsesc": "~0.5.0"
@@ -13298,12 +12753,12 @@
 			"dev": true
 		},
 		"resolve": {
-			"version": "1.22.3",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.3.tgz",
-			"integrity": "sha512-P8ur/gp/AmbEzjr729bZnLjXK5Z+4P0zhIJgBgzqRih7hL7BOukHGtSTA3ACMY467GRFz3duQsi0bDZdR7DKdw==",
+			"version": "2.0.0-next.5",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.5.tgz",
+			"integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
 			"dev": true,
 			"requires": {
-				"is-core-module": "^2.12.0",
+				"is-core-module": "^2.13.0",
 				"path-parse": "^1.0.7",
 				"supports-preserve-symlinks-flag": "^1.0.0"
 			}
@@ -13357,6 +12812,15 @@
 				"glob": "^7.1.3"
 			}
 		},
+		"run-applescript": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-5.0.0.tgz",
+			"integrity": "sha512-XcT5rBksx1QdIhlFOCtgZkB99ZEouFZ1E2Kc2LHqNW13U3/74YGdkQRmThTwxy4QIyookibDKYZOPqX//6BlAg==",
+			"dev": true,
+			"requires": {
+				"execa": "^5.0.0"
+			}
+		},
 		"run-parallel": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -13367,13 +12831,13 @@
 			}
 		},
 		"safe-array-concat": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.0.0.tgz",
-			"integrity": "sha512-9dVEFruWIsnie89yym+xWTAYASdpw3CJV7Li/6zBewGf9z2i1j31rP6jnY0pHEO4QZh6N0K11bFjWmdR8UGdPQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.0.1.tgz",
+			"integrity": "sha512-6XbUAseYE2KtOuGueyeobCySj9L4+66Tn6KQMOPQJrAJEowYKW/YR/MGJZl7FdydUdaFu4LYyDZjxf4/Nmo23Q==",
 			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
-				"get-intrinsic": "^1.2.0",
+				"get-intrinsic": "^1.2.1",
 				"has-symbols": "^1.0.3",
 				"isarray": "^2.0.5"
 			}
@@ -13382,15 +12846,6 @@
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
 			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-		},
-		"safe-regex": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz",
-			"integrity": "sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==",
-			"dev": true,
-			"requires": {
-				"regexp-tree": "~0.1.1"
-			}
 		},
 		"safe-regex-test": {
 			"version": "1.0.0",
@@ -13450,6 +12905,29 @@
 				"randombytes": "^2.1.0"
 			}
 		},
+		"set-function-length": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.1.1.tgz",
+			"integrity": "sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==",
+			"dev": true,
+			"requires": {
+				"define-data-property": "^1.1.1",
+				"get-intrinsic": "^1.2.1",
+				"gopd": "^1.0.1",
+				"has-property-descriptors": "^1.0.0"
+			}
+		},
+		"set-function-name": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.1.tgz",
+			"integrity": "sha512-tMNCiqYVkXIZgc2Hnoy2IvC/f8ezc5koaRFkCjrpWzGpCd3qbZXPzVy9MAZzK1ch/X0jvSkojys3oqJN0qCmdA==",
+			"dev": true,
+			"requires": {
+				"define-data-property": "^1.0.1",
+				"functions-have-names": "^1.2.3",
+				"has-property-descriptors": "^1.0.0"
+			}
+		},
 		"shebang-command": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -13483,9 +12961,9 @@
 			"dev": true
 		},
 		"slash": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+			"integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
 			"dev": true
 		},
 		"slice-ansi": {
@@ -13504,13 +12982,6 @@
 			"integrity": "sha512-vzn8aSqKgytVik0iwdBEi+zevbTYZogewTUM6dtpmGwEcdzbub/TX4bCzRhebDCRC3QzXgJsLRKB2V/Oof7HXg==",
 			"requires": {
 				"is-plain-obj": "^1.0.0"
-			},
-			"dependencies": {
-				"is-plain-obj": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-					"integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg=="
-				}
 			}
 		},
 		"sort-keys-length": {
@@ -13566,9 +13037,9 @@
 			}
 		},
 		"spdx-license-ids": {
-			"version": "3.0.13",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.13.tgz",
-			"integrity": "sha512-XkD+zwiqXHikFZm4AX/7JSCXA98U5Db4AFd5XUg/+9UNtnH75+Z9KxtpYiJZx36mUDVOwH83pl7yvCer6ewM3w==",
+			"version": "3.0.16",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.16.tgz",
+			"integrity": "sha512-eWN+LnM3GR6gPu35WxNgbGl8rmY1AEmoMDvL/QD6zYmPWgywxWqJWNdLGT+ke8dKNWrcYgYjPpG5gbTfghP8rw==",
 			"dev": true
 		},
 		"sprintf-js": {
@@ -13595,9 +13066,9 @@
 			}
 		},
 		"streamx": {
-			"version": "2.15.0",
-			"resolved": "https://registry.npmjs.org/streamx/-/streamx-2.15.0.tgz",
-			"integrity": "sha512-HcxY6ncGjjklGs1xsP1aR71INYcsXFJet5CU1CHqihQ2J5nOsbd4OjgjHO42w/4QNv9gZb3BueV+Vxok5pLEXg==",
+			"version": "2.15.6",
+			"resolved": "https://registry.npmjs.org/streamx/-/streamx-2.15.6.tgz",
+			"integrity": "sha512-q+vQL4AAz+FdfT137VF69Cc/APqUbxy+MDOImRrMvchJpigHj9GksgDU2LYbO9rx7RX6osWgxJB2WxhYv4SZAw==",
 			"requires": {
 				"fast-fifo": "^1.1.0",
 				"queue-tick": "^1.0.1"
@@ -13623,36 +13094,36 @@
 			}
 		},
 		"string.prototype.trim": {
-			"version": "1.2.7",
-			"resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.7.tgz",
-			"integrity": "sha512-p6TmeT1T3411M8Cgg9wBTMRtY2q9+PNy9EV1i2lIXUN/btt763oIfxwN3RR8VU6wHX8j/1CFy0L+YuThm6bgOg==",
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.8.tgz",
+			"integrity": "sha512-lfjY4HcixfQXOfaqCvcBuOIapyaroTXhbkfJN3gcB1OtyupngWK4sEET9Knd0cXd28kTUqu/kHoV4HKSJdnjiQ==",
 			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.4",
-				"es-abstract": "^1.20.4"
+				"define-properties": "^1.2.0",
+				"es-abstract": "^1.22.1"
 			}
 		},
 		"string.prototype.trimend": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz",
-			"integrity": "sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.7.tgz",
+			"integrity": "sha512-Ni79DqeB72ZFq1uH/L6zJ+DKZTkOtPIHovb3YZHQViE+HDouuU4mBrLOLDn5Dde3RF8qw5qVETEjhu9locMLvA==",
 			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.4",
-				"es-abstract": "^1.20.4"
+				"define-properties": "^1.2.0",
+				"es-abstract": "^1.22.1"
 			}
 		},
 		"string.prototype.trimstart": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.6.tgz",
-			"integrity": "sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.7.tgz",
+			"integrity": "sha512-NGhtDFu3jCEm7B4Fy0DpLewdJQOZcQ0rGbwQ/+stjnrp2i+rlKeCvos9hOIeCmqwratM47OBxY7uFZzjxHXmrg==",
 			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.4",
-				"es-abstract": "^1.20.4"
+				"define-properties": "^1.2.0",
+				"es-abstract": "^1.22.1"
 			}
 		},
 		"strip-ansi": {
@@ -13677,13 +13148,6 @@
 			"requires": {
 				"inspect-with-kind": "^1.0.5",
 				"is-plain-obj": "^1.1.0"
-			},
-			"dependencies": {
-				"is-plain-obj": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-					"integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg=="
-				}
 			}
 		},
 		"strip-final-newline": {
@@ -13706,11 +13170,6 @@
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
 			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
 			"dev": true
-		},
-		"strip-outer": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-2.0.0.tgz",
-			"integrity": "sha512-A21Xsm1XzUkK0qK1ZrytDUvqsQWict2Cykhvi0fBQntGG5JSprESasEyV1EZ/4CiR5WB5KjzLTrP/bO37B0wPg=="
 		},
 		"strtok3": {
 			"version": "7.0.0",
@@ -13758,6 +13217,16 @@
 			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
 			"dev": true
 		},
+		"synckit": {
+			"version": "0.8.6",
+			"resolved": "https://registry.npmjs.org/synckit/-/synckit-0.8.6.tgz",
+			"integrity": "sha512-laHF2savN6sMeHCjLRkheIU4wo3Zg9Ln5YOjOo7sZ5dVQW8yF5pPE5SIw1dsPhq3TRp1jisKRCdPhfs/1WMqDA==",
+			"dev": true,
+			"requires": {
+				"@pkgr/utils": "^2.4.2",
+				"tslib": "^2.6.2"
+			}
+		},
 		"tapable": {
 			"version": "0.1.10",
 			"resolved": "https://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz",
@@ -13775,15 +13244,15 @@
 			}
 		},
 		"temp-dir": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
-			"integrity": "sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-3.0.0.tgz",
+			"integrity": "sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==",
 			"dev": true
 		},
 		"terser": {
-			"version": "5.19.2",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.19.2.tgz",
-			"integrity": "sha512-qC5+dmecKJA4cpYxRa5aVkKehYsQKc+AHeKl0Oe62aYjBL8ZA33tTljktDHJSaxxMnbI5ZYw+o/S2DxxLu8OfA==",
+			"version": "5.26.0",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.26.0.tgz",
+			"integrity": "sha512-dytTGoE2oHgbNV9nTzgBEPaqAWvcJNl66VZ0BkJqlvp71IjO8CxdBx/ykCNb47cLnCmCvRZ6ZR0tLkqvZCdVBQ==",
 			"dev": true,
 			"peer": true,
 			"requires": {
@@ -13835,6 +13304,12 @@
 			"integrity": "sha512-TIsDdtKo6+XrPtiTm1ssmMngN1sAhyKnTO2kunQWqNPWIVvCm15Wmw4SWInwTVgJ5u/Tr04+8Ei9TNcw4x4ONA==",
 			"dev": true
 		},
+		"titleize": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/titleize/-/titleize-3.0.0.tgz",
+			"integrity": "sha512-KxVu8EYHDPBdUYdKZdKtU2aj2XfEx9AfjXxE/Aj0vT06w2icA09Vus1rh6eSu1y01akYg6BjIK/hxyLJINoMLQ==",
+			"dev": true
+		},
 		"to-absolute-glob": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-3.0.0.tgz",
@@ -13863,19 +13338,12 @@
 				"ieee754": "^1.2.1"
 			}
 		},
-		"trim-newlines": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-4.1.1.tgz",
-			"integrity": "sha512-jRKj0n0jXWo6kh62nA5TEh3+4igKDXLvzBJcPpiizP7oOolUrYIxmVBG9TOtHYFHoddUk6YvAkGeGoSVTXfQXQ==",
-			"dev": true
-		},
-		"trim-repeated": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-2.0.0.tgz",
-			"integrity": "sha512-QUHBFTJGdOwmp0tbOG505xAgOp/YliZP/6UgafFXYZ26WT1bvQmSMJUvkeVSASuJJHbqsFbynTvkd5W8RBTipg==",
-			"requires": {
-				"escape-string-regexp": "^5.0.0"
-			}
+		"ts-api-utils": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.3.tgz",
+			"integrity": "sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==",
+			"dev": true,
+			"requires": {}
 		},
 		"tsconfig-paths": {
 			"version": "3.14.2",
@@ -13888,6 +13356,12 @@
 				"minimist": "^1.2.6",
 				"strip-bom": "^3.0.0"
 			}
+		},
+		"tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+			"dev": true
 		},
 		"type-check": {
 			"version": "0.4.0",
@@ -13952,9 +13426,9 @@
 			}
 		},
 		"typescript": {
-			"version": "5.1.6",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-			"integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+			"version": "5.3.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+			"integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
 			"dev": true
 		},
 		"unbox-primitive": {
@@ -13984,10 +13458,23 @@
 			"integrity": "sha512-eXL4nmJT7oCpkZsHZUOJo8hcX3GbsiDOa0Qu9F646fi8dT3XuSVopVqAcEiVzSKKH7UoDti23wNX3qGFxcW5Qg==",
 			"dev": true
 		},
+		"undici-types": {
+			"version": "5.26.5",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+			"dev": true,
+			"peer": true
+		},
+		"untildify": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
+			"integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
+			"dev": true
+		},
 		"update-browserslist-db": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz",
-			"integrity": "sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==",
+			"version": "1.0.13",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
+			"integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
 			"dev": true,
 			"peer": true,
 			"requires": {
@@ -14005,9 +13492,9 @@
 			}
 		},
 		"url-or-path": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/url-or-path/-/url-or-path-2.1.0.tgz",
-			"integrity": "sha512-dsBD6GbytSMj9YDb3jVzSRENwFh50oUORnWBeSHfo0Lnwv2KMm/J4npyGy1P9rivUPsUGLjTA53XqAFqpe0nww==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/url-or-path/-/url-or-path-2.3.0.tgz",
+			"integrity": "sha512-5g9xpEJKjbAY8ikLU3XFpEg3hRLGt6SbCQmDElb1AL7JTW6vMi5Na5e3dMvONHisIu9VHgMAADLHJ8EznYR2ow==",
 			"dev": true
 		},
 		"util-deprecate": {
@@ -14016,14 +13503,14 @@
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
 		},
 		"v8-to-istanbul": {
-			"version": "9.1.0",
-			"resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.1.0.tgz",
-			"integrity": "sha512-6z3GW9x8G1gd+JIIgQQQxXuiJtCXeAjp6RaPEPLv62mH3iPHPxV6W3robxtCzNErRo6ZwTmzWhsbNvjyEBKzKA==",
+			"version": "9.2.0",
+			"resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.2.0.tgz",
+			"integrity": "sha512-/EH/sDgxU2eGxajKdwLCDmQ4FWq+kpi3uCmBGpw1xJtnAxEjlD8j8PEiGWpCIMIs3ciNAgH0d3TTJiUkYzyZjA==",
 			"dev": true,
 			"requires": {
 				"@jridgewell/trace-mapping": "^0.3.12",
 				"@types/istanbul-lib-coverage": "^2.0.1",
-				"convert-source-map": "^1.6.0"
+				"convert-source-map": "^2.0.0"
 			}
 		},
 		"validate-npm-package-license": {
@@ -14048,9 +13535,9 @@
 			}
 		},
 		"webpack": {
-			"version": "5.88.2",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.88.2.tgz",
-			"integrity": "sha512-JmcgNZ1iKj+aiR0OvTYtWQqJwq37Pf683dY9bVORwVbUrDhLhdn/PlO2sHsFHPkj7sHNQF3JwaAkp49V+Sq1tQ==",
+			"version": "5.89.0",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
+			"integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
 			"dev": true,
 			"peer": true,
 			"requires": {
@@ -14154,13 +13641,13 @@
 			}
 		},
 		"which-typed-array": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.11.tgz",
-			"integrity": "sha512-qe9UWWpkeG5yzZ0tNYxDmd7vo58HDBc39mZ0xWWpolAGADdFOzkfamWLDxkOWcvHQKVmdTyQdLD4NOfjLWTKew==",
+			"version": "1.1.13",
+			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.13.tgz",
+			"integrity": "sha512-P5Nra0qjSncduVPEAr7xhoF5guty49ArDTwzJ/yNuPIbZppyRxFQsRCWrocxIY+CnMVG+qfbU2FmDKyvSGClow==",
 			"dev": true,
 			"requires": {
 				"available-typed-arrays": "^1.0.5",
-				"call-bind": "^1.0.2",
+				"call-bind": "^1.0.4",
 				"for-each": "^0.3.3",
 				"gopd": "^1.0.1",
 				"has-tostringtag": "^1.0.0"
@@ -14248,320 +13735,67 @@
 			"dev": true
 		},
 		"write-file-atomic": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
-			"integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
+			"integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
 			"dev": true,
 			"requires": {
 				"imurmurhash": "^0.1.4",
-				"signal-exit": "^3.0.7"
+				"signal-exit": "^4.0.1"
+			},
+			"dependencies": {
+				"signal-exit": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+					"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+					"dev": true
+				}
 			}
 		},
 		"xo": {
-			"version": "0.54.2",
-			"resolved": "https://registry.npmjs.org/xo/-/xo-0.54.2.tgz",
-			"integrity": "sha512-1S3r+ecCg8OVPtu711as+cgwxOg+WQNRgSzqZ+OHzYlsa8CpW3ych0Ve9k8Q2QG6gqO3HSpaS5AXi9D0yPUffg==",
+			"version": "0.56.0",
+			"resolved": "https://registry.npmjs.org/xo/-/xo-0.56.0.tgz",
+			"integrity": "sha512-ohzSqgQ8POgZ3KNaEK/gxDovb6h3cglxv8+xi9Dn7gmRe8g4qotpOZpMs5ACJhvkJDmJOhiKbk6Uq6Mx1Di9DA==",
 			"dev": true,
 			"requires": {
-				"@eslint/eslintrc": "^1.3.3",
-				"@typescript-eslint/eslint-plugin": "^5.59.1",
-				"@typescript-eslint/parser": "^5.59.1",
+				"@eslint/eslintrc": "^2.1.0",
+				"@typescript-eslint/eslint-plugin": "^6.0.0",
+				"@typescript-eslint/parser": "^6.0.0",
 				"arrify": "^3.0.0",
-				"cosmiconfig": "^8.1.3",
+				"cosmiconfig": "^8.2.0",
 				"define-lazy-prop": "^3.0.0",
-				"eslint": "^8.37.0",
+				"eslint": "^8.45.0",
 				"eslint-config-prettier": "^8.8.0",
 				"eslint-config-xo": "^0.43.1",
-				"eslint-config-xo-typescript": "^0.57.0",
+				"eslint-config-xo-typescript": "^1.0.0",
 				"eslint-formatter-pretty": "^5.0.0",
 				"eslint-import-resolver-webpack": "^0.13.2",
 				"eslint-plugin-ava": "^14.0.0",
 				"eslint-plugin-eslint-comments": "^3.2.0",
-				"eslint-plugin-import": "^2.27.5",
-				"eslint-plugin-n": "^15.7.0",
+				"eslint-plugin-import": "~2.27.5",
+				"eslint-plugin-n": "^16.0.1",
 				"eslint-plugin-no-use-extend-native": "^0.5.0",
-				"eslint-plugin-prettier": "^4.2.1",
-				"eslint-plugin-unicorn": "^46.0.0",
+				"eslint-plugin-prettier": "^5.0.0",
+				"eslint-plugin-unicorn": "^48.0.0",
 				"esm-utils": "^4.1.2",
 				"find-cache-dir": "^4.0.0",
 				"find-up": "^6.3.0",
 				"get-stdin": "^9.0.0",
-				"get-tsconfig": "^4.5.0",
-				"globby": "^13.1.2",
+				"get-tsconfig": "^4.6.2",
+				"globby": "^13.2.2",
 				"imurmurhash": "^0.1.4",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
 				"lodash-es": "^4.17.21",
-				"meow": "^11.0.0",
+				"meow": "^12.0.1",
 				"micromatch": "^4.0.5",
 				"open-editor": "^4.0.0",
-				"prettier": "^2.8.7",
-				"semver": "^7.3.8",
-				"slash": "^5.0.0",
+				"prettier": "^3.0.0",
+				"semver": "^7.5.4",
+				"slash": "^5.1.0",
 				"to-absolute-glob": "^3.0.0",
-				"typescript": "^5.0.3"
+				"typescript": "^5.1.6"
 			},
 			"dependencies": {
-				"@eslint-community/eslint-utils": {
-					"version": "4.4.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"eslint-visitor-keys": "^3.3.0"
-					}
-				},
-				"@eslint-community/regexpp": {
-					"version": "4.5.0",
-					"bundled": true,
-					"dev": true
-				},
-				"@nodelib/fs.scandir": {
-					"version": "2.1.5",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"@nodelib/fs.stat": "2.0.5",
-						"run-parallel": "^1.1.9"
-					}
-				},
-				"@nodelib/fs.stat": {
-					"version": "2.0.5",
-					"bundled": true,
-					"dev": true
-				},
-				"@nodelib/fs.walk": {
-					"version": "1.2.8",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"@nodelib/fs.scandir": "2.1.5",
-						"fastq": "^1.6.0"
-					}
-				},
-				"@types/json-schema": {
-					"version": "7.0.11",
-					"bundled": true,
-					"dev": true
-				},
-				"@types/semver": {
-					"version": "7.3.13",
-					"bundled": true,
-					"dev": true
-				},
-				"@typescript-eslint/eslint-plugin": {
-					"version": "5.59.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"@eslint-community/regexpp": "^4.4.0",
-						"@typescript-eslint/scope-manager": "5.59.1",
-						"@typescript-eslint/type-utils": "5.59.1",
-						"@typescript-eslint/utils": "5.59.1",
-						"debug": "^4.3.4",
-						"grapheme-splitter": "^1.0.4",
-						"ignore": "^5.2.0",
-						"natural-compare-lite": "^1.4.0",
-						"semver": "^7.3.7",
-						"tsutils": "^3.21.0"
-					}
-				},
-				"@typescript-eslint/parser": {
-					"version": "5.59.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"@typescript-eslint/scope-manager": "5.59.1",
-						"@typescript-eslint/types": "5.59.1",
-						"@typescript-eslint/typescript-estree": "5.59.1",
-						"debug": "^4.3.4"
-					}
-				},
-				"@typescript-eslint/scope-manager": {
-					"version": "5.59.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"@typescript-eslint/types": "5.59.1",
-						"@typescript-eslint/visitor-keys": "5.59.1"
-					}
-				},
-				"@typescript-eslint/type-utils": {
-					"version": "5.59.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"@typescript-eslint/typescript-estree": "5.59.1",
-						"@typescript-eslint/utils": "5.59.1",
-						"debug": "^4.3.4",
-						"tsutils": "^3.21.0"
-					}
-				},
-				"@typescript-eslint/types": {
-					"version": "5.59.1",
-					"bundled": true,
-					"dev": true
-				},
-				"@typescript-eslint/typescript-estree": {
-					"version": "5.59.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"@typescript-eslint/types": "5.59.1",
-						"@typescript-eslint/visitor-keys": "5.59.1",
-						"debug": "^4.3.4",
-						"globby": "^11.1.0",
-						"is-glob": "^4.0.3",
-						"semver": "^7.3.7",
-						"tsutils": "^3.21.0"
-					},
-					"dependencies": {
-						"globby": {
-							"version": "11.1.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"array-union": "^2.1.0",
-								"dir-glob": "^3.0.1",
-								"fast-glob": "^3.2.9",
-								"ignore": "^5.2.0",
-								"merge2": "^1.4.1",
-								"slash": "^3.0.0"
-							}
-						},
-						"slash": {
-							"version": "3.0.0",
-							"bundled": true,
-							"dev": true
-						}
-					}
-				},
-				"@typescript-eslint/utils": {
-					"version": "5.59.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"@eslint-community/eslint-utils": "^4.2.0",
-						"@types/json-schema": "^7.0.9",
-						"@types/semver": "^7.3.12",
-						"@typescript-eslint/scope-manager": "5.59.1",
-						"@typescript-eslint/types": "5.59.1",
-						"@typescript-eslint/typescript-estree": "5.59.1",
-						"eslint-scope": "^5.1.1",
-						"semver": "^7.3.7"
-					}
-				},
-				"@typescript-eslint/visitor-keys": {
-					"version": "5.59.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"@typescript-eslint/types": "5.59.1",
-						"eslint-visitor-keys": "^3.3.0"
-					}
-				},
-				"array-union": {
-					"version": "2.1.0",
-					"bundled": true,
-					"dev": true
-				},
-				"braces": {
-					"version": "3.0.2",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"fill-range": "^7.0.1"
-					}
-				},
-				"debug": {
-					"version": "4.3.4",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"ms": "2.1.2"
-					},
-					"dependencies": {
-						"ms": {
-							"version": "2.1.2",
-							"bundled": true,
-							"dev": true
-						}
-					}
-				},
-				"dir-glob": {
-					"version": "3.0.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"path-type": "^4.0.0"
-					}
-				},
-				"eslint-config-xo-typescript": {
-					"version": "0.57.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {}
-				},
-				"eslint-scope": {
-					"version": "5.1.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"esrecurse": "^4.3.0",
-						"estraverse": "^4.1.1"
-					},
-					"dependencies": {
-						"estraverse": {
-							"version": "4.3.0",
-							"bundled": true,
-							"dev": true
-						}
-					}
-				},
-				"eslint-visitor-keys": {
-					"version": "3.4.0",
-					"bundled": true,
-					"dev": true
-				},
-				"esrecurse": {
-					"version": "4.3.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"estraverse": "^5.2.0"
-					}
-				},
-				"estraverse": {
-					"version": "5.3.0",
-					"bundled": true,
-					"dev": true
-				},
-				"fast-glob": {
-					"version": "3.2.12",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"@nodelib/fs.stat": "^2.0.2",
-						"@nodelib/fs.walk": "^1.2.3",
-						"glob-parent": "^5.1.2",
-						"merge2": "^1.3.0",
-						"micromatch": "^4.0.4"
-					}
-				},
-				"fastq": {
-					"version": "1.15.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"reusify": "^1.0.4"
-					}
-				},
-				"fill-range": {
-					"version": "7.0.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"to-regex-range": "^5.0.1"
-					}
-				},
 				"find-up": {
 					"version": "6.3.0",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-6.3.0.tgz",
@@ -14572,42 +13806,6 @@
 						"path-exists": "^5.0.0"
 					}
 				},
-				"glob-parent": {
-					"version": "5.1.2",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"is-glob": "^4.0.1"
-					}
-				},
-				"grapheme-splitter": {
-					"version": "1.0.4",
-					"bundled": true,
-					"dev": true
-				},
-				"ignore": {
-					"version": "5.2.4",
-					"bundled": true,
-					"dev": true
-				},
-				"is-extglob": {
-					"version": "2.1.1",
-					"bundled": true,
-					"dev": true
-				},
-				"is-glob": {
-					"version": "4.0.3",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"is-extglob": "^2.1.1"
-					}
-				},
-				"is-number": {
-					"version": "7.0.0",
-					"bundled": true,
-					"dev": true
-				},
 				"locate-path": {
 					"version": "7.2.0",
 					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
@@ -14616,25 +13814,6 @@
 					"requires": {
 						"p-locate": "^6.0.0"
 					}
-				},
-				"merge2": {
-					"version": "1.4.1",
-					"bundled": true,
-					"dev": true
-				},
-				"micromatch": {
-					"version": "4.0.5",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"braces": "^3.0.2",
-						"picomatch": "^2.3.1"
-					}
-				},
-				"natural-compare-lite": {
-					"version": "1.4.0",
-					"bundled": true,
-					"dev": true
 				},
 				"p-limit": {
 					"version": "4.0.0",
@@ -14654,83 +13833,11 @@
 						"p-limit": "^4.0.0"
 					}
 				},
-				"path-type": {
-					"version": "4.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"picomatch": {
-					"version": "2.3.1",
-					"bundled": true,
-					"dev": true
-				},
-				"queue-microtask": {
-					"version": "1.2.3",
-					"bundled": true,
-					"dev": true
-				},
-				"reusify": {
-					"version": "1.0.4",
-					"bundled": true,
-					"dev": true
-				},
-				"run-parallel": {
-					"version": "1.2.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"queue-microtask": "^1.2.2"
-					}
-				},
-				"semver": {
-					"version": "7.5.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					},
-					"dependencies": {
-						"lru-cache": {
-							"version": "6.0.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"yallist": "^4.0.0"
-							}
-						},
-						"yallist": {
-							"version": "4.0.0",
-							"bundled": true,
-							"dev": true
-						}
-					}
-				},
 				"slash": {
 					"version": "5.1.0",
 					"resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
 					"integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
 					"dev": true
-				},
-				"to-regex-range": {
-					"version": "5.0.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"is-number": "^7.0.0"
-					}
-				},
-				"tslib": {
-					"version": "1.14.1",
-					"bundled": true,
-					"dev": true
-				},
-				"tsutils": {
-					"version": "3.21.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"tslib": "^1.8.1"
-					}
 				},
 				"yocto-queue": {
 					"version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
 				"xo": "^0.54.2"
 			},
 			"engines": {
-				"node": "^14.14.0 || >=16.0.0"
+				"node": ">=16"
 			}
 		},
 		"node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -42,12 +42,12 @@
 		"@xhmikosr/archive-type": "^6.0.1",
 		"@xhmikosr/decompress": "^9.0.1",
 		"content-disposition": "^0.5.4",
+		"defaults": "^2.0.1",
 		"ext-name": "^5.0.0",
 		"file-type": "^18.5.0",
 		"filenamify": "^5.1.1",
 		"get-stream": "^6.0.1",
 		"got": "^12.6.1",
-		"merge-options": "^3.0.4",
 		"p-event": "^5.0.1"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -42,21 +42,21 @@
 		"@xhmikosr/archive-type": "^6.0.1",
 		"@xhmikosr/decompress": "^9.0.1",
 		"content-disposition": "^0.5.4",
-		"defaults": "^2.0.1",
+		"defaults": "^2.0.2",
 		"ext-name": "^5.0.0",
-		"file-type": "^18.5.0",
-		"filenamify": "^5.1.1",
+		"file-type": "^18.7.0",
+		"filenamify": "^6.0.0",
 		"get-stream": "^6.0.1",
-		"got": "^12.6.1",
-		"p-event": "^5.0.1"
+		"got": "^13.0.0",
+		"p-event": "^6.0.0"
 	},
 	"devDependencies": {
-		"ava": "^4.3.3",
+		"ava": "^5.3.1",
 		"c8": "^8.0.1",
 		"is-zip": "^1.0.0",
-		"nock": "^13.3.2",
+		"nock": "^13.4.0",
 		"path-exists": "^5.0.0",
-		"xo": "^0.54.2"
+		"xo": "^0.56.0"
 	},
 	"xo": {
 		"rules": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"url": "https://github.com/kevva"
 	},
 	"engines": {
-		"node": "^14.14.0 || >=16.0.0"
+		"node": ">=16"
 	},
 	"scripts": {
 		"ava": "ava",


### PR DESCRIPTION
On hold until some time has passed for projects to drop Node.js 14 support.