### PR TITLE
Replace defaults with structuredClone

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,6 @@ import process from 'node:process';
 import contentDisposition from 'content-disposition';
 import archiveType from '@xhmikosr/archive-type';
 import decompress from '@xhmikosr/decompress';
-import defaults from 'defaults';
 import extName from 'ext-name';
 import {fileTypeFromBuffer} from 'file-type';
 import filenamify from 'filenamify';
@@ -72,7 +71,7 @@ const download = (uri, output, options) => {
 
 	options = {
 		...options,
-		got: defaults(options?.got, defaultGotOptions),
+		got: {...structuredClone(defaultGotOptions), ...options?.got},
 		decompress: options?.decompress ?? {},
 	};
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
 				"@xhmikosr/archive-type": "^7.1.0",
 				"@xhmikosr/decompress": "^10.1.0",
 				"content-disposition": "^0.5.4",
-				"defaults": "^2.0.2",
 				"ext-name": "^5.0.0",
 				"file-type": "^20.5.0",
 				"filenamify": "^6.0.0",
@@ -2539,18 +2538,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/defaults": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/defaults/-/defaults-2.0.2.tgz",
-			"integrity": "sha512-cuIw0PImdp76AOfgkjbW4VhQODRmNNcKR73vdCH5cLd/ifj7aamfoXvYgfGkEAjNJZ3ozMIy9Gu2LutUkGEPbA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=16"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
 		"@xhmikosr/archive-type": "^7.1.0",
 		"@xhmikosr/decompress": "^10.1.0",
 		"content-disposition": "^0.5.4",
-		"defaults": "^2.0.2",
 		"ext-name": "^5.0.0",
 		"file-type": "^20.5.0",
 		"filenamify": "^6.0.0",


### PR DESCRIPTION
@felipecrs WDYT?

defaults v3.0.0 was causing issues in a downstream package (https://github.com/netlify/gh-release-fetch/actions/runs/16453360448/job/46504086105?pr=430) so I downgraded it to v2.0.2 and cut a new patch release but it seems we can do without it. Can you also check if everything is fine with your bindl package?