### PR TITLE
feat!: replace thenable stream hybrid with explicit exports

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,47 +75,46 @@ const mergeDefinedOptions = (defaults, overrides = {}) => {
 	return merged;
 };
 
-const download = (uri, output, options = {}) => {
-	if (typeof output === 'object') {
-		options = output;
-		output = null;
-	}
-
-	options = {
+const buildStream = (uri, options) => {
+	const mergedOptions = {
 		...options,
 		got: mergeDefinedOptions(defaultGotOptions, options.got),
 		decompress: options.decompress ?? {},
 	};
 
-	const stream = got.stream(uri, options.got);
+	return {
+		stream: got.stream(uri, mergedOptions.got),
+		options: mergedOptions,
+	};
+};
 
-	const promise = (async () => {
-		const response = await filterEvents(stream, 'response');
-		const streamData = options.got.responseType === 'buffer' ? getStreamAsBuffer(stream) : getStream(stream);
-		const data = await streamData;
+const download = async (uri, options = {}) => {
+	const {stream, options: options_} = buildStream(uri, options);
 
-		const hasArchiveData = options.extract && await archiveType(data);
+	const response = await filterEvents(stream, 'response');
+	const streamData = options_.got.responseType === 'buffer' ? getStreamAsBuffer(stream) : getStream(stream);
+	const data = await streamData;
 
-		if (!output) {
-			return hasArchiveData ? decompress(data, options.decompress) : data;
-		}
+	const hasArchiveData = options_.extract && await archiveType(data);
 
-		const filename = options.filename || filenamify(await getFilename(response, data));
-		const outputFilepath = path.join(output, filename);
+	if (!options_.dest) {
+		return hasArchiveData ? decompress(data, options_.decompress) : data;
+	}
 
-		if (hasArchiveData) {
-			return decompress(data, path.dirname(outputFilepath), options.decompress);
-		}
+	const filename = options_.filename || filenamify(await getFilename(response, data));
+	const outputFilepath = path.join(options_.dest, filename);
 
-		await fs.mkdir(path.dirname(outputFilepath), {recursive: true});
-		await fs.writeFile(outputFilepath, data);
-		return data;
-	})();
+	if (hasArchiveData) {
+		return decompress(data, path.dirname(outputFilepath), options_.decompress);
+	}
 
-	// eslint-disable-next-line unicorn/no-thenable
-	stream.then = promise.then.bind(promise);
-	stream.catch = promise.catch.bind(promise);
+	await fs.mkdir(path.dirname(outputFilepath), {recursive: true});
+	await fs.writeFile(outputFilepath, data);
+	return data;
+};
 
+export const downloadAsStream = (uri, options = {}) => {
+	const {stream} = buildStream(uri, options);
 	return stream;
 };
 

--- a/readme.md
+++ b/readme.md
@@ -14,19 +14,22 @@ npm install @xhmikosr/downloader
 
 ```js
 import fs from 'node:fs';
-import download from '@xhmikosr/downloader';
+import download, {downloadAsStream} from '@xhmikosr/downloader';
 
 (async () => {
-	await download('http://unicorn.com/foo.jpg', 'dist');
+	await download('http://unicorn.com/foo.jpg', {dest: 'dist'});
 
 	fs.writeFileSync('dist/foo.jpg', await download('http://unicorn.com/foo.jpg'));
 
-	download('http://unicorn.com/foo.jpg').pipe(fs.createWriteStream('dist/foo.jpg'));
+	const text = await download('http://unicorn.com/foo.txt', {got: {responseType: 'text'}});
+	console.log(text);
+
+	downloadAsStream('http://unicorn.com/foo.jpg').pipe(fs.createWriteStream('dist/foo.jpg'));
 
 	await Promise.all([
 		'http://unicorn.com/foo.jpg',
 		'http://cats.com/dancing.gif'
-	].map(url => download(url, 'dist')));
+	].map(url => download(url, {dest: 'dist'})));
 })();
 ```
 
@@ -36,9 +39,13 @@ To work with proxies, read the [`got documentation`](https://github.com/sindreso
 
 ## API
 
-### download(url, destination?, options?)
+### download(url, options?)
 
-Returns both a `Promise<Buffer>` and a [Duplex stream](https://nodejs.org/api/stream.html#stream_class_stream_duplex) with [additional events](https://github.com/sindresorhus/got/blob/main/documentation/3-streams.md#events).
+Returns a Promise resolving to the downloaded data (or extracted file list when `extract` is enabled and no `dest` is provided).
+
+### downloadAsStream(url, options?)
+
+Returns a [Duplex stream](https://nodejs.org/api/stream.html#stream_class_stream_duplex) with [additional events](https://github.com/sindresorhus/got/blob/main/documentation/3-streams.md#events).
 
 #### url
 
@@ -46,13 +53,13 @@ Type: `string`
 
 URL to download.
 
-#### destination
+#### options
+
+##### options.dest
 
 Type: `string`
 
 Directory to save the file to.
-
-#### options
 
 ##### options.got
 

--- a/test.js
+++ b/test.js
@@ -10,7 +10,7 @@ import {fileTypeFromBuffer} from 'file-type';
 import {getStreamAsBuffer} from 'get-stream';
 import nock from 'nock';
 import decompressUnzip from '@xhmikosr/decompress-unzip';
-import download from './index.js';
+import download, {downloadAsStream} from './index.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -70,7 +70,7 @@ test.before(() => {
 });
 
 test('download as stream', async t => {
-	const data = await getStreamAsBuffer(download('http://foo.bar/foo.zip'));
+	const data = await getStreamAsBuffer(downloadAsStream('http://foo.bar/foo.zip'));
 	t.true(await isZip(data));
 });
 
@@ -84,47 +84,47 @@ test('download as promise', async t => {
 	t.true(await isZip(data));
 });
 
-test('preserves default got options when user passes undefined', async t => {
+test('preserves default got options when the user passes undefined', async t => {
 	const data = await download('http://foo.bar/foo.zip', {got: {responseType: undefined}});
 	t.true(await isZip(data));
 });
 
 test('download a very large file', async t => {
-	const stream = await getStreamAsBuffer(download('http://foo.bar/large.bin'));
-	t.is(stream.length, 7_928_260);
+	const data = await getStreamAsBuffer(downloadAsStream('http://foo.bar/large.bin'));
+	t.is(data.length, 7_928_260);
 });
 
 test('download and rename file', async t => {
-	await download('http://foo.bar/foo.zip', __dirname, {filename: 'bar.zip'});
+	await download('http://foo.bar/foo.zip', {dest: __dirname, filename: 'bar.zip'});
 	t.true(await pathExists(path.join(__dirname, 'bar.zip')));
 	await removeDir(path.join(__dirname, 'bar.zip'));
 });
 
 test('save file', async t => {
-	await download('http://foo.bar/foo.zip', __dirname);
+	await download('http://foo.bar/foo.zip', {dest: __dirname});
 	t.true(await pathExists(path.join(__dirname, 'foo.zip')));
 	await removeDir(path.join(__dirname, 'foo.zip'));
 });
 
 test('extract file', async t => {
-	await download('http://foo.bar/foo.zip', __dirname, {extract: true});
+	await download('http://foo.bar/foo.zip', {dest: __dirname, extract: true});
 	t.true(await pathExists(path.join(__dirname, 'file.txt')));
 	await removeDir(path.join(__dirname, 'file.txt'));
 });
 
 test('extract file with decompress plugin', async t => {
-	await download('http://foo.bar/foo.zip', __dirname, {extract: true, decompress: {plugins: [decompressUnzip()]}});
+	await download('http://foo.bar/foo.zip', {dest: __dirname, extract: true, decompress: {plugins: [decompressUnzip()]}});
 	t.true(await pathExists(path.join(__dirname, 'file.txt')));
 	await removeDir(path.join(__dirname, 'file.txt'));
 });
 
 test('extract file that is not compressed', async t => {
-	await download('http://foo.bar/foo.js', __dirname, {extract: true});
+	await download('http://foo.bar/foo.js', {dest: __dirname, extract: true});
 	t.true(await pathExists(path.join(__dirname, 'foo.js')));
 	await removeDir(path.join(__dirname, 'foo.js'));
 });
 
-test('extract without output returns files', async t => {
+test('extract without dest returns files', async t => {
 	const files = await download('http://foo.bar/foo.zip', {extract: true});
 	t.true(Array.isArray(files));
 	t.true(files.length > 0);
@@ -141,7 +141,7 @@ test('error on 404', async t => {
 });
 
 test('rename to valid filename', async t => {
-	await download('http://foo.bar/foo*bar.zip', __dirname);
+	await download('http://foo.bar/foo*bar.zip', {dest: __dirname});
 	t.true(await pathExists(path.join(__dirname, 'foo!bar.zip')));
 	await removeDir(path.join(__dirname, 'foo!bar.zip'));
 });
@@ -157,19 +157,19 @@ test('follow redirect to https', async t => {
 });
 
 test('handle query string', async t => {
-	await download('http://foo.bar/querystring.zip?param=value', __dirname);
+	await download('http://foo.bar/querystring.zip?param=value', {dest: __dirname});
 	t.true(await pathExists(path.join(__dirname, 'querystring.zip')));
 	await removeDir(path.join(__dirname, 'querystring.zip'));
 });
 
 test('handle content disposition', async t => {
-	await download('http://foo.bar/dispo', __dirname);
+	await download('http://foo.bar/dispo', {dest: __dirname});
 	t.true(await pathExists(path.join(__dirname, 'dispo.zip')));
 	await removeDir(path.join(__dirname, 'dispo.zip'));
 });
 
 test('handle filename from file type', async t => {
-	await download('http://foo.bar/filetype', __dirname);
+	await download('http://foo.bar/filetype', {dest: __dirname});
 	t.true(await pathExists(path.join(__dirname, 'filetype.zip')));
 	await removeDir(path.join(__dirname, 'filetype.zip'));
 });
@@ -194,19 +194,19 @@ test('handle filename from mime type when file-type does not support it', async 
 	const csvData = Buffer.from('id,name\n1,alice\n');
 	t.is(await fileTypeFromBuffer(csvData), undefined);
 
-	await download('http://foo.bar/mime-single', __dirname);
+	await download('http://foo.bar/mime-single', {dest: __dirname});
 	t.true(await pathExists(path.join(__dirname, 'mime-single.csv')));
 	await removeDir(path.join(__dirname, 'mime-single.csv'));
 });
 
 test('do not add extension from mime type when ambiguous', async t => {
-	await download('http://foo.bar/mime-multiple', __dirname);
+	await download('http://foo.bar/mime-multiple', {dest: __dirname});
 	t.true(await pathExists(path.join(__dirname, 'mime-multiple')));
 	await removeDir(path.join(__dirname, 'mime-multiple'));
 });
 
 test('do not add extension when content type is missing', async t => {
-	await download('http://foo.bar/mime-none', __dirname);
+	await download('http://foo.bar/mime-none', {dest: __dirname});
 	t.true(await pathExists(path.join(__dirname, 'mime-none')));
 	await removeDir(path.join(__dirname, 'mime-none'));
 });


### PR DESCRIPTION
BREAKING CHANGE: API has been split into two named exports.

- `download(url, options?)` (default export) is now a plain async function returning a Promise. The `dest` destination is now passed as `options.dest` instead of a separate positional argument.
- `downloadAsStream(url, options?)` (named export) replaces the old stream-with-.then/.catch pattern for callers that need a raw stream.